### PR TITLE
Feat/button component

### DIFF
--- a/zc_frontend/src/components/externalPagesComponents/Button.js
+++ b/zc_frontend/src/components/externalPagesComponents/Button.js
@@ -1,9 +1,28 @@
-const Button = () => {
-    return (
-        <div>
-            This is button component
-        </div>
-    )
-}
+import styles from "../../styles/Button.module.css";
 
-export default Button
+/**
+ *
+ * @param {Object} prop - button props consisting of ;
+ * 1) variant - indicating what styles to add to the default style. By default it will add the 'primary' styles. If the value is 'accent', it will not add any additional styles and you can style yourself using className or styles prop.
+ * 2) all the regular button attributes.
+ * @returns
+ */
+
+const Button = ({ variant = "primary", className = "", ...rest }) => {
+  return (
+    <button
+      className={`${styles.general_button} ${className} ${
+        variant === "secondary"
+          ? styles.general_button__secondary
+          : variant === "accent"
+          ? ""
+          : styles.general_button__primary
+      }`}
+      {...rest}
+    >
+      {rest.children}
+    </button>
+  );
+};
+
+export default Button;

--- a/zc_frontend/src/styles/Button.module.css
+++ b/zc_frontend/src/styles/Button.module.css
@@ -28,7 +28,6 @@
   border: 1px solid #069e6b;
 }
 
-.general_button__primary:active,
-.general_button__secondary:active {
+.general_button:active {
   transform: scale(0.95);
 }

--- a/zc_frontend/src/styles/Button.module.css
+++ b/zc_frontend/src/styles/Button.module.css
@@ -1,0 +1,34 @@
+.general_button {
+  padding: 0.5em 1em;
+  background: #ffffff;
+  border-radius: 3px;
+  font-family: Lato;
+  font-size: 1rem;
+  border: none;
+}
+
+.general_button__primary {
+  background: #00b87c;
+  color: #ffffff;
+  border: 1px solid #02c584;
+}
+
+.general_button__secondary {
+  background: #ffffff;
+  color: #00b87c;
+  border: 1px solid #00b87c;
+}
+.general_button__primary:hover {
+  background: #069e6b;
+  border: 1px solid #069e6b;
+}
+
+.general_button__secondary:hover {
+  color: #069e6b;
+  border: 1px solid #069e6b;
+}
+
+.general_button__primary:active,
+.general_button__secondary:active {
+  transform: scale(0.95);
+}


### PR DESCRIPTION
1. **What does this PR Do?** 

> This PR adds a general Button component that has the basic styles of the most common buttons on the app but is flexible and can be styled however you want.

2. **How to test** 

> Pull this branch, import the button component from `./src/components/externalPagesComponent/Button.js` and use it like `<Button>Click Me!</Button>`. 
> The Button component takes a prop **variant** which specifies the button's theme. The prop variant recognizes three values `'primary'`, `'secondary'`, and `'accent'`. By default `variant=" primary"`, and the button has the primary styles.  `variant = "secondary"` will add secondary styles and `variant ="accent"` will add no styles besides the default button styles, leaving it bare for you to style yourself. 
> You can extend the styles using className or style prop like normal and you can use all the attributes that a regular button can use.
3. **Demo Link** 
> https://zen-lovelace-2ec35d.netlify.app/

4. **Screenshots?**
<img width="377" alt="Screenshot 2021-08-31 at 12 47 41" src="https://user-images.githubusercontent.com/40301524/131498711-089741ff-b661-4666-9917-ba9e123fc326.png">
<img width="377" alt="Screenshot 2021-08-31 at 12 45 35" src="https://user-images.githubusercontent.com/40301524/131498728-e996b6f8-dfa6-44aa-8c73-e5b8f53f5680.png">
<img width="377" alt="Screenshot 2021-08-31 at 12 45 50" src="https://user-images.githubusercontent.com/40301524/131498760-f950bb61-c503-4915-97a2-b630701d7875.png">
