### PR TITLE
adds logoutfeature to the logoutpage close #564

### DIFF
--- a/lib/logout.js
+++ b/lib/logout.js
@@ -1,0 +1,8 @@
+const express = require('express')
+const route = express.Router()
+
+route.get('/logout', (req, res) => {
+  res.redirect('/login')
+})
+
+module.exports = route

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ const helmet = require('helmet')
 const device = require('express-device')
 const useragent = require('express-useragent')
 const sessions = require('./lib/user_session')
+const logoutRoute = require('./lib/logout')
 
 const loadFrontend = require('./middlewares/load-frontend')
 const PORT = process.env.PORT || 3000
@@ -27,6 +28,7 @@ sessions.startSession(app)
 app.use(device.capture())
 app.use(useragent.express())
 
+app.use(logoutRoute)
 routes(app)
 loadFrontend(app)
 


### PR DESCRIPTION
This feature redirect the user to the login route. 

Note: The login route is not yet created for the backend so it won't go to the login route now, it would just go the home page (zuri.chat)

The testing link https://zuri.chat/logout