### PR TITLE
(Team Aristotle) Feat/centralize package management

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,30 +15,49 @@ If the output is not the version of your nodejs installation, install nodejs fro
 After installing nodejs install [yarn](https://www.npmjs.com/package/yarn) if you don't have it then install the project's dependencies:
 
 ```bash
-yarn install
+yarn zcmain:install
 ```
 
-## Run the Server
+## STARTING THE SERVER
 
-Run the development server from the root folder using either of the following commands:
+### Backend
 
 ```bash
-npm run dev
-# or
-yarn dev
+yarn backend:serve
 ```
 
-## Run the application -- Frontend specific
+Open [http://localhost:5000](http://localhost:5000) with your browser to see the result.
 
-Open the frontend folder `zc_frontend` in your terminal and run the application from the folder using either of the following commands:
+
+### Frontend
 
 ```bash
-npm run dev
-# or
-yarn dev
-```
+yarn frontend:serve
 
+```
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+
+## RUNNING YARN COMMANDS
+
+### Backend
+
+```bash
+yarn backend <command>
+
+for example
+
+yarn backend add is-odd
+```
+
+### Frontend
+
+```bash
+yarn frontend <command>
+
+for example
+
+yarn frontend add is-odd
+```
 
 ## Editor setup
 

--- a/package.json
+++ b/package.json
@@ -14,8 +14,13 @@
     "run-start": "cross-env NODE_ENV=production node server.js",
     "run-dev": "cross-env NODE_ENV=development nodemon server.js",
     "frontend:build": "npm run build --prefix zc_frontend",
-    "frontend:dev": "cross-env PORT=5000 npm run start --prefix zc_frontend",
-    "postinstall": "cd zc_frontend && yarpm-yarn install"
+    "frontend:dev": "cross-env PORT=5000 npm start --prefix zc_frontend",
+    "postinstall": "cd zc_frontend && yarpm-yarn install",
+    "zcmain:install": "yarn && cd zc_frontend && yarn",
+    "frontend:serve": "cd zc_frontend && yarn dev",
+    "backend:serve": "yarn dev",
+    "backend": "yarn",
+    "frontend": "cd zc_frontend && yarn"
   },
   "dependencies": {
     "axios": "^0.21.1",


### PR DESCRIPTION
# (Team Aristotle) Feat/centralize package management

## WHAT DOES THIS PR DO?

* fixes issue [#964](https://github.com/zurichat/zc_main/issues/964) 
* centralizes package management in the project(perform dependency management for both FE and BE from the same folder)
* Fixes the error that made the backend not able to be served
* Enables developers to serve the frontend or backend from the same folder(project root) 

## HOW DOES IT DO THESE

* you can now run `yarn  zcmain:install` to install dependencies for the whole project(front and back ends), you can also install packages for FE or BE from the project root(see README for more details)
* installed a missing dependency that was making the express server not to serve
* you can now run `yarn backend:serve` or `yarn frontend:serve` as needed

## HOW DO I TEST THESE?

* clone my fork `git clone https://github.com/tobecci/zc_main.git`
* checkout to the `feat/centralizeManagement` by doing `git checkout feat/centralizeManagement`
* then test out the commands `yarn zcmain:install`, `yarn backend:serve`
* the project should serve

> Thanks for making it this far