### PR TITLE
Implemented polishing on drop menu from user icon based on the ticket assigned by Mark

### DIFF
--- a/zc_frontend/src/styles/Topbar.module.css
+++ b/zc_frontend/src/styles/Topbar.module.css
@@ -379,12 +379,12 @@
   /* set yourself as away*/
   .away {
     position: absolute;
-    right: 88px;
+    right: 183px;
   }
 
   /* set yourself as active*/
   .active {
     position: absolute;
-    right: 85px;
+    right: 180px;
   }
 }


### PR DESCRIPTION
I carried out final responsive polishing on the media query for mobile (375) for the "set as away" and "set as active" states.

The changes were made at the Topbar.module.css, with the code below:
`@media only screen and (min-width: 320px) and (max-width: 768px) {
  /* set yourself as away*/
  .away {
    position: absolute;
    right: 183px;
  }

  /* set yourself as active*/
  .active {
    position: absolute;
    right: 180px;
  }
}`

