### PR TITLE
ZC-00384 (Row Number 376) fix-bug: change the sidebar hover_color to match the style_guard 

### DIFF
--- a/sidebar/src/styles/Sidebar.module.css
+++ b/sidebar/src/styles/Sidebar.module.css
@@ -1,21 +1,27 @@
 /* @import url('https://fonts.googleapis.com/css2?family=Lato&display=swap'); */
 
 .sb__container {
-  font-family: Lato;
+  font: "Lato", sans-serif;
   border-right: 1px solid rgba(0, 0, 0, 0.1);
-  background-color: #ffffff;
+  background-color: #fff;
   padding-block-end: 3em;
   height: 100%;
   width: unset;
   font-size: 16px;
+
   /* display: flex;
   flex-direction: column; */
+
   /* overflow: auto; */
+
   /* width: 100%; */
+
   /* overflow-y: scroll; */
+
   /* padding-top: 4.3rem; */
 }
-/* 
+
+/*
 .row {
 } */
 
@@ -30,6 +36,7 @@
 .subCon2::-webkit-scrollbar {
   display: none;
 }
+
 .orgDiv {
   width: inherit;
   height: 44px;
@@ -64,13 +71,16 @@
 .sb__item {
   margin-bottom: 0.25em;
   margin-top: 0.1em;
+
   /* margin: 0.5em 0; */
 }
+
 .sb__item:hover {
-  background-color: #999999;
+  background-color: #f1fffa;
 }
+
 .sb__item::selection {
-  background-color: rosybrown;
+  background-color: #f1fffa;
 }
 
 .sb__col {
@@ -100,21 +110,31 @@
 } */
 
 /* .newMessage { */
+
 /* border-radius: 50%; */
+
 /* width: auto; */
+
 /* background-color: #ffffff; */
+
 /* align-self: center; */
+
 /* margin-left: 6.6875em;
   margin-right: 1.25em; */
+
 /* display: flex;
   align-items: center;
   justify-content: center; */
+
 /* } */
 
 /* .newMsgIcon { */
+
 /* height: 100%;
   width: 4em; */
+
 /* z-index: 100; */
+
 /* } */
 
 /* .container ul {
@@ -169,6 +189,7 @@
   /* height: 3.125em; *
   height: 7vh;
   /* display: flex; */
+
 /* flex-direction: row; *
 } */
 
@@ -209,12 +230,12 @@
 }
 
 .channelHeader p {
-  font-family: Lato;
+  font: "Lato", sans-serif;
   font-style: normal;
   font-weight: 500;
   font-size: 15px;
   line-height: 18px;
-  color: #999999;
+  color: #999;
 }
 
 .channelDropdownIcon {
@@ -228,18 +249,19 @@
 
 .channelNames {
   margin-left: 3.5em;
-  font-family: Lato;
+  font: "Lato", sans-serif;
   font-style: normal;
   font-weight: bold;
   font-size: 15px;
   line-height: 18px;
-  color: #999999;
+  color: #999;
 }
 
 .channelNames p > span {
   margin-right: 0.5em;
 }
 
+/*
 .messagesContainer {
   margin-top: 0.5em;
 }
@@ -253,14 +275,15 @@
 }
 
 .messageHeader p {
-  font-family: Lato;
+   font: "Lato", sans-serif;
   font-style: normal;
   font-weight: 500;
   font-size: 15px;
   line-height: 18px;
   color: #999999;
-}
+} */
 
+/*
 .messageDropdownIcon {
   margin: 1em 1em 1em 0;
 }
@@ -272,17 +295,18 @@
 
 .messageNames {
   margin-left: 3.5em;
-  font-family: Lato;
+  font: "Lato", sans-serif;
   font-style: normal;
   font-weight: bold;
   font-size: 15px;
   line-height: 18px;
   color: #999999;
-}
+} */
 
+/*
 .messageNames p > span {
   margin-right: 0.5em;
-}
+} */
 
 .messagesContainer {
   margin-top: 0.5em;
@@ -297,12 +321,12 @@
 }
 
 .messageHeader p {
-  font-family: Lato;
+  font: "Lato", sans-serif;
   font-style: normal;
   font-weight: 500;
   font-size: 15px;
   line-height: 18px;
-  color: #999999;
+  color: #999;
 }
 
 .messageDropdownIcon {
@@ -316,12 +340,12 @@
 
 .messageNames {
   margin-left: 2.5em;
-  font-family: Lato;
+  font: "Lato", sans-serif;
   font-style: normal;
   font-weight: 500;
   font-size: 15px;
   line-height: 18px;
-  color: #999999;
+  color: #999;
 }
 
 .messageNames p {


### PR DESCRIPTION
ZC-00384 (Row Number 376) fix-bug: change the sidebar hover_color to match the style_guard

![SideBar_Hover_Color](https://user-images.githubusercontent.com/65835404/136639888-eb192af4-fa5d-4aec-afb3-8c5ffda77d92.jpg)

FULLY LINTED (passed all stylelint's conditions) 
This PR changes the hover - background color of the sidebar text-elements as shown above


Linear Issue-Link - https://linear.app/zuri/issue/ZC-2036/zc-00384-bugs
Link to Spreadsheet cell - https://docs.google.com/spreadsheets/d/1oOIrdm6FEvrBPug8hZ7Gzz9q6ubMTc_a1G9bf_revq8/edit#gid=1595165527&range=F376