### PR TITLE
Fix: organization name extending over two lines when logged in

### DIFF
--- a/sidebar/src/styles/Sidebar.module.css
+++ b/sidebar/src/styles/Sidebar.module.css
@@ -267,7 +267,7 @@
   color: #999;
 }
 
-.channelNames p>span {
+.channelNames p > span {
   margin-right: 0.5em;
 }
 
@@ -364,7 +364,7 @@
   align-items: center;
 }
 
-.messageNames p>span {
+.messageNames p > span {
   margin-right: 0.5em;
 }
 


### PR DESCRIPTION
As per mark request, The org name extends over two lines when you are logged in