### PR TITLE
Fixed the Hamburger icon on outside click close

### DIFF
--- a/control/src/component-styles/HeaderStyle.module.css
+++ b/control/src/component-styles/HeaderStyle.module.css
@@ -6,14 +6,7 @@
 .navbar {
   border-bottom: 1px solid rgba(187, 186, 231, 0.15);
   padding: 0.5rem 1rem;
-<<<<<<< HEAD
-  width: 105%;
-=======
-  top: 0;
-  z-index: 100;
-  position: fixed;
   width: 100%;
->>>>>>> bffa53d570c290a7384933efea609e9caf408d34
   background-color: white;
   display: flex;
   justify-content: space-around;
@@ -135,22 +128,21 @@
   margin-right: 12px;
 }
 
-<<<<<<< HEAD
 @media screen and (max-width: 992px) {
   .navContainer {
-     top: 0;
-  z-index: 100;
+    top: 0;
+    z-index: 100;
     width: 100vw;
     height: 100vh;
   }
 
-  .bg_overlay{
-background-color: rgba(11, 11, 12, 0.658);
-=======
+  .bg_overlay {
+    background-color: rgba(11, 11, 12, 0.658);
+  }
+}
 @media screen and (max-width: 1000px) {
   .navbarBrand {
     margin-right: auto !important;
->>>>>>> bffa53d570c290a7384933efea609e9caf408d34
   }
 }
 

--- a/control/src/components/Header.js
+++ b/control/src/components/Header.js
@@ -36,11 +36,6 @@ const HeaderSearchSuggestion = () => {
     }
   }, [])
 
-/*   useEffect(() => {
-    document
-      .querySelector(".navbar-toggler")
-      .addEventListener(onclick, toggleBgOverlay)
-  }, []) */
 
   return (
     <div className={headerStyles.navContainer}>
@@ -68,7 +63,7 @@ const HeaderSearchSuggestion = () => {
         </Link>
         <button
           className={`navbar-toggler ${headerStyles.toggle}`}
-          onClick={()=>console.log(document)}
+          onClick={toggleBgOverlay}
           type="button"
           data-bs-toggle="collapse"
           data-bs-target="#navbarText"


### PR DESCRIPTION
1. The Hamburger icon on mobile wouldn't close unless it reclicked. Fixed the outside menu collapse for it, Incase the user decide against navigating to another page, when he clicks out the navigation menu collapse
2. On Hamburger icon click, there is a background overlayed on the rest of the content, in other not to distract the user.