### PR TITLE
[ZCG_7] Remove unnecessary options from preferences panel

### DIFF
--- a/packages/main/src/components/protected/sidebar/hooks/useSidebarItems.js
+++ b/packages/main/src/components/protected/sidebar/hooks/useSidebarItems.js
@@ -1,0 +1,93 @@
+import React, { useEffect, useReducer } from "react";
+import { subscribeToChannel } from "@zuri/utilities";
+import { reducer, ACTIONS } from "../reducers/sidebar.reducer";
+import { fetchUser } from "../utils/fetch-user-details";
+
+const categories = [
+  "games",
+  "utility",
+  "tools",
+  "entertainment",
+  "sales",
+  "productivity",
+  "channels",
+  "direct messages",
+  "others"
+];
+
+const useSidebarItems = () => {
+  const [state, dispatch] = useReducer(reducer, {});
+  const currentWorkspace = localStorage.getItem("currentWorkspace");
+
+  let singleItems = [];
+  let categorizedItems = [];
+  let starredRooms = [];
+
+  useEffect(() => {
+    //Load user related information when component mounts
+    fetchUser(dispatch);
+  }, []);
+
+  useEffect(() => {
+    if (state?.user?.user._id && state.sidebar) {
+      subscribeToChannel(
+        `${currentWorkspace}_${state?.user?.user._id}_sidebar`,
+        ctx => {
+          const websocket = ctx.data;
+          // console.log("websocket", websocket)
+          if (websocket.event === "sidebar_update") {
+            let sidebar_update = { [websocket.plugin_id]: websocket.data };
+            //Update sidebar with recent changes
+            dispatch({
+              type: ACTIONS.UPDATE_PLUGINS,
+              payload: sidebar_update
+            });
+          }
+        }
+      );
+    }
+  }, [state, currentWorkspace, dispatch]);
+
+  if (state?.sidebar) {
+    for (let key in state.sidebar) {
+      if (!categories.includes(key)) {
+        continue;
+      } else if (key == "others") {
+        singleItems = Object.keys(state.sidebar[key]).map((k, idx) => {
+          var data = state.sidebar[key][k];
+          return {
+            id: `${data.name}${idx}`,
+            name: data.joined_rooms[0].room_name,
+            image: data.joined_rooms[0].room_image,
+            link: data.joined_rooms[0].room_url
+          };
+        });
+      } else {
+        const categoryData = Object.keys(state.sidebar[key]).map((k, id) => {
+          const data = state.sidebar[key][k];
+          data.baseUrl = `https://${k}`;
+          data.id = id;
+          return data;
+        });
+        categorizedItems.push({
+          id: categoryData[0]?.name,
+          name: { key },
+          data: { categoryData }
+        });
+
+        starredRooms = Object.keys(state.sidebar[key]).map(
+          (k, id) => state.sidebar[key][k].starred_rooms
+        );
+      }
+    }
+  }
+
+  return {
+    singleItems,
+    categorizedItems,
+    starredRooms,
+    isLoading: Boolean(state?.isLoading)
+  };
+};
+
+export default useSidebarItems;

--- a/packages/main/src/components/protected/sidebar/index.jsx
+++ b/packages/main/src/components/protected/sidebar/index.jsx
@@ -12,7 +12,11 @@ export default function App() {
     const sideBar = document.getElementById(
       "single-spa-application:@zuri/sidebar"
     );
-    sideBar.style.backgroundColor = themeColors[theme]?.primary;
+
+    // Ensure the sidebar is mounted before changing the theme
+    if (sideBar) {
+      sideBar.style.backgroundColor = themeColors[theme]?.primary;
+    }
   }
 
   useEffect(() => {

--- a/packages/main/src/components/protected/sidebar/utils/fetch-user-details.js
+++ b/packages/main/src/components/protected/sidebar/utils/fetch-user-details.js
@@ -4,6 +4,10 @@ import { getOrgDetails } from "./get-org-details";
 
 export const fetchUser = async dispatch => {
   try {
+    dispatch({
+      type: ACTIONS.IS_LOADING,
+      payload: true
+    });
     const user = await getUserInfo();
 
     //Get workspace info
@@ -17,6 +21,10 @@ export const fetchUser = async dispatch => {
       //set organization details
       getOrgDetails(dispatch, currentWorkspace, user.email, user.user._id);
     }
+    dispatch({
+      type: ACTIONS.IS_LOADING,
+      payload: false
+    });
   } catch (err) {
     console.warn(err);
   }

--- a/packages/main/src/components/protected/topbar/components/AdvancedSettings.jsx
+++ b/packages/main/src/components/protected/topbar/components/AdvancedSettings.jsx
@@ -1,8 +1,10 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useReducer, useState } from "react";
+import { TiArrowSortedDown } from "react-icons/ti";
+import SkeletonLoader from "../../sidebar/components/SkeletonLoader";
+import useSidebarItems from "../../sidebar/hooks/useSidebarItems";
 import { ProfileContext } from "../context/profile-modal.context";
 import styles from "../styles/AdvancedSettings.module.css";
 import standardStyles from "../styles/UserPreference.module.css";
-
 import { authAxios } from "../utils/api";
 
 const colorOptions = [
@@ -30,42 +32,108 @@ const customStyles = {
 
 const AdvancedSettings = () => {
   const { user } = useContext(ProfileContext);
+  const { categorizedItems, singleItems } = useSidebarItems();
 
-  // console.log("user", user.settings.advanced)
-  const [advance, setAdvance] = useState(user.settings.advanced);
-
-  const updateAdvanceSettings = advance => {
-    authAxios
-      .patch(
-        `/organizations/${user.org_id}/members/${user._id}/settings/advanced`,
-        advance
-      )
-      .then(res => {
-        // console.log(res)
-      })
-      .catch(err => {
-        // console.log(err)
-      });
-  };
-
-  const handleSelect = selectedOptions => {
-    let options = [];
-
-    selectedOptions.forEach(option => {
-      options.push(option.value);
-    });
-
-    let newAdvance = { ...advance, excluded_channels: options };
-
-    updateAdvanceSettings(newAdvance);
-  };
+  const allItems = [
+    ...categorizedItems.map(c => ({
+      id: c.id,
+      name: c.id
+    })),
+    ...singleItems
+  ];
 
   return (
     <div className={standardStyles.modalContent}>
-      {/* <div className={styles.spacingLeft}> */}
-      {/* <h5 className={styles.head}>Input options</h5> */}
+      <div className={styles.container}>
+        <h5 className={standardStyles.labelTextHeader}>Plugin Options</h5>
+        <p className={styles.note}>
+          Change options specific to plugins in this workspace.
+        </p>
 
-      {/* <div className={styles.checkInputGroup}>
+        {allItems?.length > 0 ? (
+          <div className={styles.pluginOptionsContainer}>
+            {allItems?.map(item => {
+              return <PluginOptionsDropdown key={item.id} label={item.name} />;
+            })}
+          </div>
+        ) : (
+          <SkeletonLoader COUNTER={2} />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default AdvancedSettings;
+
+const PluginOptionsDropdown = ({ options, label }) => {
+  const [open, setOpen] = useState(false);
+
+  const toggleDropdown = () => setOpen(!open);
+
+  return (
+    <div className={styles.pluginOptionWrapper}>
+      <button className={styles.dropdownContainer} onClick={toggleDropdown}>
+        <TiArrowSortedDown
+          className={styles.dropdownIcon}
+          style={{
+            transform: open ? "rotate(0deg)" : "rotate(270deg)"
+          }}
+        />
+        <div className={styles.dropdownTitle}>{label}</div>
+      </button>
+      {open && (
+        <div className={styles.dropdownContent}>
+          {/* Not implemented yet */}
+          <p className={styles.note}>No options available</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+/**
+ * Old component code
+ */
+
+// console.log("user", user.settings.advanced)
+// const [advance, setAdvance] = useState(user.settings.advanced);
+
+// const updateAdvanceSettings = advance => {
+//   authAxios
+//     .patch(
+//       `/organizations/${user.org_id}/members/${user._id}/settings/advanced`,
+//       advance
+//     )
+//     .then(res => {
+//       // console.log(res)
+//     })
+//     .catch(err => {
+//       // console.log(err)
+//     });
+// };
+
+// const handleSelect = selectedOptions => {
+//   let options = [];
+
+//   selectedOptions.forEach(option => {
+//     options.push(option.value);
+//   });
+
+//   let newAdvance = { ...advance, excluded_channels: options };
+
+//   updateAdvanceSettings(newAdvance);
+// };
+
+{
+  /* <div className={styles.spacingLeft}> */
+}
+{
+  /* <h5 className={styles.head}>Input options</h5> */
+}
+
+{
+  /* <div className={styles.checkInputGroup}>
           <input 
             type="checkbox" 
             checked={advance.input_option.dont_send_with_enter}
@@ -85,8 +153,10 @@ const AdvancedSettings = () => {
             </p>
             <p className={styles.inputParagraph60}>With this ticked, use <span className={styles.highlights}>Shift</span> to send</p>
           </div>
-        </div> */}
-      {/* <div className={styles.checkInputGroup}>
+        </div> */
+}
+{
+  /* <div className={styles.checkInputGroup}>
           <input type="checkbox" 
             name="" id="" 
             className={styles.chekedInput} 
@@ -107,10 +177,14 @@ const AdvancedSettings = () => {
               The text formatting toolbar won’t show in the composer
             </p>
           </div>
-        </div> */}
-      {/* <p className={styles.head}>When writing a message, press </p> */}
+        </div> */
+}
+{
+  /* <p className={styles.head}>When writing a message, press </p> */
+}
 
-      {/* <div className={styles.radioInputContainer}>
+{
+  /* <div className={styles.radioInputContainer}>
           <input 
             className={styles.radioInput} 
             type="radio" 
@@ -126,8 +200,10 @@ const AdvancedSettings = () => {
             }}
           />
           <div className={styles.radioInfo} htmlFor="writting_message1">Send the message</div>
-        </div> */}
-      {/* <div className={styles.radioInputContainer}>
+        </div> */
+}
+{
+  /* <div className={styles.radioInputContainer}>
           <input 
             className={styles.radioInput} 
             type="radio" 
@@ -143,15 +219,25 @@ const AdvancedSettings = () => {
             }}
           />
           <div className={styles.radioInfo} htmlFor="writting_message2">Start a new line ( use <span className={styles.highlights}>Ctrl</span> <span className={styles.highlights}>Enter</span> to send )</div>
-        </div> */}
+        </div> */
+}
 
-      {/* </div> */}
-      {/* <div className={styles.line}></div> */}
+{
+  /* </div> */
+}
+{
+  /* <div className={styles.line}></div> */
+}
 
-      {/* <div className={styles.spacingLeft}> */}
-      {/* <h5 className={styles.head}>Search Options</h5> */}
+{
+  /* <div className={styles.spacingLeft}> */
+}
+{
+  /* <h5 className={styles.head}>Search Options</h5> */
+}
 
-      {/* <div className={styles.checkInputGroup2}>
+{
+  /* <div className={styles.checkInputGroup2}>
           <input 
             type="checkbox" 
             name="" id="" 
@@ -171,8 +257,10 @@ const AdvancedSettings = () => {
             </p>
             <p className={styles.inputParagraph60}>Overrides normal behavaiour in search behaviour</p>
           </div>
-        </div> */}
-      {/* <div className={styles.checkInputGroup2}>
+        </div> */
+}
+{
+  /* <div className={styles.checkInputGroup2}>
           <input 
             type="checkbox" 
             name="" id="" 
@@ -192,10 +280,14 @@ const AdvancedSettings = () => {
             </p>
             <p className={styles.inputParagraph60}>Overrides normal behavaiour in some browsers</p>
           </div>
-        </div> */}
+        </div> */
+}
 
-      {/* <h5 className={styles.head}>Exclude these channels from search results:</h5> */}
-      {/* <Select
+{
+  /* <h5 className={styles.head}>Exclude these channels from search results:</h5> */
+}
+{
+  /* <Select
           isMulti
           name="colors"
           styles={customStyles}
@@ -206,12 +298,18 @@ const AdvancedSettings = () => {
           onChange={(selectedOptions) => {
             handleSelect(selectedOptions)
           }}
-        /> */}
-      {/* </div> */}
+        /> */
+}
+{
+  /* </div> */
+}
 
-      {/* <div className={styles.line}></div> */}
+{
+  /* <div className={styles.line}></div> */
+}
 
-      {/* <div className={styles.checkInputGroup2}>
+{
+  /* <div className={styles.checkInputGroup2}>
           <input 
             type="checkbox" 
             name="" id="" 
@@ -234,10 +332,14 @@ const AdvancedSettings = () => {
               keys always scroll messages
             </p>
           </div>
-        </div> */}
-      <div className={styles.container}>
-        {/* <h5 className={standardStyles.labelTextHeader}>Input Options</h5> */}
-        {/* <div className={standardStyles.labelContainer}>
+        </div> */
+}
+
+{
+  /* <h5 className={standardStyles.labelTextHeader}>Input Options</h5> */
+}
+{
+  /* <div className={standardStyles.labelContainer}>
           <input
             type="checkbox"
             name=""
@@ -262,8 +364,10 @@ const AdvancedSettings = () => {
             Ask if I want to toggle my away status when I log in after having
             set myself away
           </div>
-        </div> */}
-        {/* <div className={standardStyles.labelContainer}>
+        </div> */
+}
+{
+  /* <div className={standardStyles.labelContainer}>
           <input
             type="checkbox"
             name=""
@@ -287,14 +391,18 @@ const AdvancedSettings = () => {
           <div className={standardStyles.labelSubtext}>
             Send me occassional survey via Zurichat bot
           </div>
-        </div> */}
-        {/* <div className={standardStyles.labelContainer}>
+        </div> */
+}
+{
+  /* <div className={standardStyles.labelContainer}>
           <div className={styles.alonetext}>
             We’re working to make Zurichat better. We’d love to hear your
             thoughts
           </div>
-        </div> */}
-        {/* <div className={standardStyles.labelContainer}>
+        </div> */
+}
+{
+  /* <div className={standardStyles.labelContainer}>
           <input
             type="checkbox"
             name=""
@@ -318,10 +426,5 @@ const AdvancedSettings = () => {
           <div className={standardStyles.labelSubtext}>
             Warn me about potential malicious links
           </div>
-        </div> */}
-      </div>
-    </div>
-  );
-};
-
-export default AdvancedSettings;
+        </div> */
+}

--- a/packages/main/src/components/protected/topbar/components/AdvancedSettings.jsx
+++ b/packages/main/src/components/protected/topbar/components/AdvancedSettings.jsx
@@ -236,8 +236,8 @@ const AdvancedSettings = () => {
           </div>
         </div> */}
       <div className={styles.container}>
-        <h5 className={standardStyles.labelTextHeader}>Input Options</h5>
-        <div className={standardStyles.labelContainer}>
+        {/* <h5 className={standardStyles.labelTextHeader}>Input Options</h5> */}
+        {/* <div className={standardStyles.labelContainer}>
           <input
             type="checkbox"
             name=""
@@ -262,8 +262,8 @@ const AdvancedSettings = () => {
             Ask if I want to toggle my away status when I log in after having
             set myself away
           </div>
-        </div>
-        <div className={standardStyles.labelContainer}>
+        </div> */}
+        {/* <div className={standardStyles.labelContainer}>
           <input
             type="checkbox"
             name=""
@@ -287,14 +287,14 @@ const AdvancedSettings = () => {
           <div className={standardStyles.labelSubtext}>
             Send me occassional survey via Zurichat bot
           </div>
-        </div>
+        </div> */}
         {/* <div className={standardStyles.labelContainer}>
           <div className={styles.alonetext}>
             We’re working to make Zurichat better. We’d love to hear your
             thoughts
           </div>
         </div> */}
-        <div className={standardStyles.labelContainer}>
+        {/* <div className={standardStyles.labelContainer}>
           <input
             type="checkbox"
             name=""
@@ -318,7 +318,7 @@ const AdvancedSettings = () => {
           <div className={standardStyles.labelSubtext}>
             Warn me about potential malicious links
           </div>
-        </div>
+        </div> */}
       </div>
     </div>
   );

--- a/packages/main/src/components/protected/topbar/components/LanguageAndRegion.jsx
+++ b/packages/main/src/components/protected/topbar/components/LanguageAndRegion.jsx
@@ -155,7 +155,7 @@ const LanguageAndRegion = () => {
               emails, for times in your activity feeds and for reminders.
             </p>
           </div>
-          <div className={styles.section}>
+          {/* <div className={styles.section}>
             <div className={styles.subhead} htmlFor="spell-check">
               Spell check
             </div>
@@ -196,7 +196,7 @@ const LanguageAndRegion = () => {
               Choose the languages you’d like Zurichat to spellcheck as you
               type.
             </p>
-          </div>
+          </div> */}
         </form>
       </div>
     </div>

--- a/packages/main/src/components/protected/topbar/components/NotificationPreference.jsx
+++ b/packages/main/src/components/protected/topbar/components/NotificationPreference.jsx
@@ -329,7 +329,7 @@ const NotificationPreference = () => {
             <label htmlFor="for-thread">Notify me of replies to thread</label>
           </div> */}
         </form>
-        <hr className={standardStyles.hrLine} />
+        {/* <hr className={standardStyles.hrLine} /> */}
         {/* <div className={styles.itemTitle2}>
           <h4 className={styles.titleSmall}>Keywords</h4>{" "}
           <span className={styles.spanBlock}>
@@ -345,15 +345,15 @@ const NotificationPreference = () => {
         </div> */}
         {/* <hr className={styles.hrNot} /> */}
 
-        <div className={styles.itemTitle2}>
+        {/* <div className={styles.itemTitle2}>
           <h4 className={styles.titleSmall}>Schedule Notification </h4>{" "}
           <span className={styles.spanBlock}>
             You'll only receive notifications in the hours that you choose.
             Outside of those times, notifications will be paused. <br />{" "}
             <span className={styles.spanSmall}>Learn more</span>
           </span>
-        </div>
-        <div className={styles.schedule}>
+        </div> */}
+        {/* <div className={styles.schedule}>
           <ul className={styles.list} style={{ paddingLeft: "0" }}>
             <li className={standardStyles.spacingRight}>
               <div className={styles.select}>
@@ -389,7 +389,7 @@ const NotificationPreference = () => {
               <TextInput label="to" />
             </li>
           </ul>
-        </div>
+        </div> */}
 
         {/* <hr className={styles.hrNot} /> */}
 
@@ -461,7 +461,7 @@ const NotificationPreference = () => {
             </div>
           </div>
         </div> */}
-        <hr className={standardStyles.hrLine} />
+        {/* <hr className={standardStyles.hrLine} /> */}
 
         {/* <div className={styles.section2}>
           <div className={styles.itemTitle2}>

--- a/packages/main/src/components/protected/topbar/components/PreferenceMenu.jsx
+++ b/packages/main/src/components/protected/topbar/components/PreferenceMenu.jsx
@@ -18,13 +18,13 @@ const PreferenceMenu = () => {
           <p style={{ marginBottom: 0 }}>Notifications</p>
         </div>
 
-        <div
+        {/* <div
           onClick={() => setSideBar(3)}
           className={sideBar === 3 ? styles.active : styles.one}
         >
           <AiOutlineEye className={styles.icon} />
           <p style={{ marginBottom: 0 }}>Themes</p>
-        </div>
+        </div> */}
         <div
           onClick={() => setSideBar(4)}
           className={sideBar === 4 ? styles.active : styles.one}

--- a/packages/main/src/components/protected/topbar/components/Preferences.jsx
+++ b/packages/main/src/components/protected/topbar/components/Preferences.jsx
@@ -76,7 +76,7 @@ const Preferences = () => {
           id="preferences-main-box"
         >
           {sideBar === 1 && <NotificationPreference />}
-          {sideBar === 3 && <Themes /*{...{ check, setCheck, setMode }}*/ />}
+          {/* {sideBar === 3 && <Themes {...{ check, setCheck, setMode }} />} */}
           {sideBar === 4 && <MessagesMedia />}
           {sideBar === 5 && <LanguageAndRegion />}
           {/* {sideBar === 6 && <Accessibility />} */}

--- a/packages/main/src/components/protected/topbar/styles/AdvancedSettings.module.css
+++ b/packages/main/src/components/protected/topbar/styles/AdvancedSettings.module.css
@@ -77,6 +77,19 @@
   margin: 0;
 }
 
+.note {
+  font-family: Lato;
+  width: 100%;
+  font-size: 13px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 20px;
+  letter-spacing: 0em;
+  text-align: left;
+  color: var(--text-color-gray);
+  margin-bottom: 10px;
+}
+
 .inputParagraph60,
 .inputParagraph40 {
   color: var(--text-color-normal);
@@ -127,6 +140,35 @@
   margin-left: 3rem;
   width: 130%;
   margin-bottom: 0.75rem;
+}
+
+.dropdownContainer {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.dropdownContainer:hover,
+.dropdownContainer::selection {
+  background-color: #f1fffa;
+}
+
+.pluginOptionWrapper {
+  width: 100%;
+}
+
+.dropdownContent {
+  padding: 0.5rem;
+  padding-left: 1.5rem;
+}
+
+.pluginOptionsContainer {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding-top: 1rem;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Description
This PR removes the following options from the preferences panel. Code for the deleted options are commented out instead of completely deleted so they can be revisited if need be.

This PR also adds a fix for an issue causing the app to break when a theme was selected. Although that should not matter much since this PR also removes the theme selection option

## Changes
- Themes
	- Removed entire theme panel  
- Notifications
	- Removed schedule notification section
- Languages & Region
	- Removed spell check section
-  Advanced 
	- Removed Input options 
	- Added "Plugin Options" section
- Sidebar
	- Added useSidebarItems hook to abstract & reuse sidebar item fetching logic

## Screenshots
### Requested Changes
![image](https://user-images.githubusercontent.com/87580113/200187807-3f326898-e78c-45e4-a699-9d219f5a594c.png)
![image](https://user-images.githubusercontent.com/87580113/200187810-0367cd54-b835-4edf-9f8e-016334b3b70d.png)
![image](https://user-images.githubusercontent.com/87580113/200187818-92626768-848f-4b64-b5db-c998781d953f.png)
![image](https://user-images.githubusercontent.com/87580113/200187822-627e4bec-4253-487e-9f1b-a100d91e6395.png)

### After Changes
![image](https://user-images.githubusercontent.com/87580113/200187852-7af4b151-066d-4be8-9ea1-b7603124e8c7.png)
![image](https://user-images.githubusercontent.com/87580113/200187856-9aff5729-5005-4a3a-b954-532014d2d3f5.png)
![image](https://user-images.githubusercontent.com/87580113/200187868-f07359ff-7561-4a57-879a-ad396c91eb86.png)



