### PR TITLE
ZUR-99:feat: Added the hover tooltip for the status

### DIFF
--- a/packages/main/src/components/protected/topbar/components/TopNavbar.jsx
+++ b/packages/main/src/components/protected/topbar/components/TopNavbar.jsx
@@ -152,15 +152,17 @@ const TopNavbar = () => {
 
   const StatusToolTip = ({ title }) => {
     return (
-      <ReactTooltip
-        id="toggleStatus"
-        effect="solid"
-        type="dark"
-        offset="{'bottom': -10, 'left': 20}"
-        arrowColor="transparent"
-      >
-        {title}
-      </ReactTooltip>
+      <div className={styles["status__tool__tip"]}>
+        <ReactTooltip
+          id="toggleStatus"
+          effect="solid"
+          place="bottom"
+          type="dark"
+          offset="{'top': 3, 'left': 0.8}"
+        >
+          {title}
+        </ReactTooltip>
+      </div>
     );
   };
 

--- a/packages/main/src/components/protected/topbar/components/TopNavbar.jsx
+++ b/packages/main/src/components/protected/topbar/components/TopNavbar.jsx
@@ -152,7 +152,13 @@ const TopNavbar = () => {
 
   const StatusToolTip = ({ title }) => {
     return (
-      <ReactTooltip id="toggleStatus" place="left" effect="solid" type="dark">
+      <ReactTooltip
+        id="toggleStatus"
+        effect="solid"
+        type="dark"
+        offset="{'bottom': -10, 'left': 20}"
+        arrowColor="transparent"
+      >
         {title}
       </ReactTooltip>
     );

--- a/packages/main/src/components/protected/topbar/components/TopNavbar.jsx
+++ b/packages/main/src/components/protected/topbar/components/TopNavbar.jsx
@@ -150,18 +150,28 @@ const TopNavbar = () => {
 
   let toggleStatus = null;
 
+  const StatusToolTip = ({ title }) => {
+    return (
+      <ReactTooltip id="toggleStatus" place="left" effect="solid" type="dark">
+        {title}
+      </ReactTooltip>
+    );
+  };
+
   switch (presence) {
     case "true":
       toggleStatus = (
         <ToggleStatus>
-          <div className="user-active" />
+          <div className="user-active" data-tip data-for="toggleStatus" />
+          <StatusToolTip title="Active" />
         </ToggleStatus>
       );
       break;
     default:
       toggleStatus = (
         <ToggleStatus>
-          <div className="user-away" />
+          <div className="user-away" data-tip data-for="toggleStatus" />
+          <StatusToolTip title="Away" />
         </ToggleStatus>
       );
   }

--- a/packages/main/src/components/protected/topbar/styles/TopNavBar.module.css
+++ b/packages/main/src/components/protected/topbar/styles/TopNavBar.module.css
@@ -16,38 +16,38 @@
   }
 }
 
-.mobile__sidebar__open ,
+.mobile__sidebar__open,
 .mobile__sidebar {
-  top:48px;
-  width:17.9em;
-  position:fixed;
-  left:0px;
-  background-color:white;
-  display:block;
-  z-index:5;
-  box-shadow:rgba(17, 17, 26, 0.1) 0px 4px 16px, rgba(17, 17, 26, 0.05) 0px 8px 32px;
+  top: 48px;
+  width: 17.9em;
+  position: fixed;
+  left: 0px;
+  background-color: white;
+  display: block;
+  z-index: 5;
+  box-shadow: rgba(17, 17, 26, 0.1) 0px 4px 16px,
+    rgba(17, 17, 26, 0.05) 0px 8px 32px;
   visibility: visible;
-
 }
 
 .mobile__sidebar {
   -webkit-transform: translate3d(-100%, 0, 0);
-	transform: translate3d(-100%, 0, 0);
-	-webkit-transition: -webkit-transform 0.5s;
-	transition: transform 0.5s;
+  transform: translate3d(-100%, 0, 0);
+  -webkit-transition: -webkit-transform 0.5s;
+  transition: transform 0.5s;
 }
 
- .mobile__sidebar__open  {
-	-webkit-transform: translate3d(0, 0, 0);
-	transform: translate3d(0, 0, 0);
+.mobile__sidebar__open {
+  -webkit-transform: translate3d(0, 0, 0);
+  transform: translate3d(0, 0, 0);
 }
 
 .mobile__sidebar::after {
-	display: none;
+  display: none;
 }
 
 @media only screen and (min-width: 768px) {
-  .mobile__sidebar__open ,
+  .mobile__sidebar__open,
   .mobile__sidebar {
     display: none;
   }
@@ -55,4 +55,8 @@
 
 .topNavBar__logo {
   width: 100%;
+}
+
+.status__tool__tip div {
+  padding: 2px 7px;
 }


### PR DESCRIPTION
What does this PR do?

This PR fixes: [https://linear.app/zurichat2/issue/ZUR-99/add-the-hover-tooltip-for-the-status](https://linear.app/zurichat2/issue/ZUR-99/add-the-hover-tooltip-for-the-status)

Added hover tooltip for the status at the top bar in the profile




![profile-status](https://user-images.githubusercontent.com/29509047/201152021-32e14d46-5c87-49b6-a90b-324a92ec21b5.png)



![profile-status-tooltip](https://user-images.githubusercontent.com/29509047/201452248-dd9cc44c-9d1d-4c79-93e9-e06ec9163359.png)


Position tool tip under profile icon:

![profile-status-tooltip1](https://user-images.githubusercontent.com/29509047/201468574-89259312-8bbd-4342-b17d-efd7c39ad4c4.png)


![profile-status-tooltip2](https://user-images.githubusercontent.com/29509047/201468512-5cd09470-4d27-4b6a-bc35-23ca71a4ab1b.png)

