### PR TITLE
ZUR-140 My PR centers the text on the left side of the icons in the create-workspace page

### DIFF
--- a/packages/main/src/pages/protected/create-workspace/Step0.jsx
+++ b/packages/main/src/pages/protected/create-workspace/Step0.jsx
@@ -90,9 +90,10 @@ const Wrapper = styled.div`
 
 const TopSection = styled.section`
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 1fr;
+  width: 100%;
+  place-items: center;
   padding-top: 132px;
-  padding-left: 55px;
 
   @media (max-width: 1000px) {
     display: flex;

--- a/packages/main/src/pages/protected/create-workspace/Step0.jsx
+++ b/packages/main/src/pages/protected/create-workspace/Step0.jsx
@@ -117,6 +117,7 @@ const Heading = styled.h1`
   margin-bottom: 14px;
   color: #333333;
   line-height: 56px;
+  text-align: center;
 
   @media (max-width: 35rem) {
     font-size: 28px;
@@ -134,6 +135,7 @@ const Text = styled.p`
   line-height: 26.91px;
   color: #333333;
   margin-bottom: 29px;
+  text-align: center;
   @media (max-width: 35rem) {
     font-size: 1rem;
     line-height: 23.92px;
@@ -188,6 +190,7 @@ const FadedText = styled.p`
   max-width: 325px;
   line-height: 18.78px;
   margin-top: 9px;
+  text-align: center;
 `;
 
 const ImageSection = styled.div`
@@ -198,4 +201,8 @@ const ImageSection = styled.div`
     }
   }
 `;
-const TextSection = styled.div``;
+const TextSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;

--- a/packages/main/src/pages/protected/create-workspace/Step0.jsx
+++ b/packages/main/src/pages/protected/create-workspace/Step0.jsx
@@ -34,7 +34,7 @@ export default function Index() {
       <Wrapper>
         <TopSection
           style={
-            user === true ? { paddingBottom: "0" } : { paddingBottom: "50px" }
+            user === true ? { paddingBottom: "0" } : { paddingBottom: "25px" }
           }
         >
           <TextSection>
@@ -86,6 +86,7 @@ export default function Index() {
 
 const Wrapper = styled.div`
   display: flex;
+  padding: 5rem 0 0 0;
 `;
 
 const TopSection = styled.section`
@@ -93,13 +94,13 @@ const TopSection = styled.section`
   grid-template-columns: 1fr;
   width: 100%;
   place-items: center;
-  padding-top: 132px;
+  padding-top: 40px;
 
   @media (max-width: 1000px) {
     display: flex;
     flex-direction: column-reverse;
     grid-template-columns: 1fr;
-    padding-top: 105px;
+    padding-top: 55px;
     padding-left: 24px;
     padding-right: 24px;
     align-items: center;
@@ -109,23 +110,22 @@ const Heading = styled.h1`
   margin: 0;
   font-family: "Lato", sans-serif;
   font-weight: 700;
-  font-size: 48px;
-  width: 320px;
+  font-size: 56px;
   margin-bottom: 14px;
   color: #333333;
   line-height: 56px;
   text-align: center;
 
   @media (max-width: 35rem) {
-    font-size: 28px;
+    font-size: 35px;
     line-height: 33.6px;
-    width: 191px;
+    width: 250px;
   }
 `;
 
 const Text = styled.p`
   margin: 0;
-  max-width: 510px;
+  max-width: 650px;
   font-weight: 400;
   font-family: "Lato", sans-serif;
   font-size: ${18 / 16}rem;


### PR DESCRIPTION
This PR changes the style in the CreateWorkspace component default page to enable the texts on the left of the icons be centered.

Solves the issue: https://linear.app/zurichat2/issue/ZUR-140/text-at-the-left-side-of-the-icons-in-the-create-workspace-should-be

Below is a screenshot of the initial look.
![ZUR-140-initial](https://user-images.githubusercontent.com/95919605/201181757-f6168a8d-fa96-4b0f-99c5-507132eaadde.jpg)



This is a screenshot of the fixed look where the left-sided texts are properly centered.
![ZUR-140-fixed](https://user-images.githubusercontent.com/95919605/201182339-2796f814-a71a-4644-8cd0-36e5778348ce.jpg)



This is the mobile view of the fixed page.
![ZUR-140-mobile](https://user-images.githubusercontent.com/95919605/201182433-c04b8383-e4a1-4d94-b161-d6f77378c0a7.jpg)
