### PR TITLE
ZUR-102 Updated the padding for the icon in the search bar in the status modal

### DIFF
--- a/packages/main/src/components/protected/topbar/styles/SetStatusModal.module.css
+++ b/packages/main/src/components/protected/topbar/styles/SetStatusModal.module.css
@@ -113,7 +113,7 @@
 .defalutEmoji {
   height: 20px;
   width: 25px;
-  padding: 0px 2px;
+  padding: 0px;
 }
 .emoji {
   display: flex;


### PR DESCRIPTION
I updated the padding for the icon in the search bar in the status modal, setting the top, bottom, left, and right padding to 0px.

https://linear.app/zurichat2/issue/ZUR-102/fix-smiley-icon-padding-in-the-search-bar-in-the-status-modal

![Screenshot 2022-11-10 220345](https://user-images.githubusercontent.com/104218719/201206096-46c6347b-ca15-4426-8353-be1a18428142.png)
![Screenshot 2022-11-10 220416](https://user-images.githubusercontent.com/104218719/201206123-b8131683-ff25-4e75-8fe3-d73f1e037391.png)
![Screenshot 2022-11-10 221047](https://user-images.githubusercontent.com/104218719/201206708-fe6f25de-2e1f-49bf-a1ed-ae3ddb5d356b.png)
