### PR TITLE
ZUR-95: improvement - Autofocus when the search bar is clicked

### DIFF
--- a/packages/main/src/components/protected/topbar/components/TopBarSearchModal.jsx
+++ b/packages/main/src/components/protected/topbar/components/TopBarSearchModal.jsx
@@ -90,6 +90,12 @@ const TopBarSearchModal = () => {
             </button>
           </li>
         ));
+
+  const handleSearchInputFocus = () => {
+    const input = document.getElementById("searchCursor");
+    input.focus();
+    input.setSelectionRange(input.value.length, input.value.length);
+  };
   return (
     <div className={styles.topBarSearchModal}>
       <div className={styles._input}>
@@ -109,6 +115,7 @@ const TopBarSearchModal = () => {
           onKeyUp={onSearchSubmit}
           className={styles._input2}
           data-testid="topbar_search_input_testid"
+          onFocus={handleSearchInputFocus}
         />
       </div>
       <div
@@ -135,6 +142,9 @@ const TopBarSearchModal = () => {
                 value={value}
                 onChange={onInputChange}
                 onKeyUp={onSearchSubmit}
+                autoFocus={"autofocus"}
+                id="searchCursor"
+                ref={ref => ref && ref.focus()}
               />
             </div>
             <div className={styles.close_icon}>


### PR DESCRIPTION
**Improvement on the Search bar autoFocus.**

When I click on the global search bar I should have the search bar focus automatically. 

_Before autofocus code was added:_

![beforeAutoFocus](https://user-images.githubusercontent.com/63932011/201279864-902225d6-3032-442b-9bf8-b809fad228c9.gif)


_After autofocus code:_

![autoFocus](https://user-images.githubusercontent.com/63932011/201279456-7f654cd0-d11c-4f55-9ec1-2e5b801852b3.gif)

