### PR TITLE
Added padding before the create account link in the login page

### DIFF
--- a/packages/main/src/components/form/AuthFormWrapper.module.css
+++ b/packages/main/src/components/form/AuthFormWrapper.module.css
@@ -279,7 +279,7 @@
   /* font-size: 1.2em; */
   /* color: #1a61db; */
   text-decoration: none;
-  margin-left: 0.4em;
+  margin-left: 0.3em;
 }
 
 .footer {

--- a/packages/main/src/components/form/AuthFormWrapper.module.css
+++ b/packages/main/src/components/form/AuthFormWrapper.module.css
@@ -279,7 +279,7 @@
   /* font-size: 1.2em; */
   /* color: #1a61db; */
   text-decoration: none;
-  margin-left: 0.3em;
+  padding-left: 0.4em;
 }
 
 .footer {


### PR DESCRIPTION
### Previous state of the site to be adjusted
![site-adjustment-1](https://user-images.githubusercontent.com/99731766/201311136-6270ea0f-77a0-41b1-8102-e4a2cae39725.png)

### Recent state of the site after adjustment
![site-adjustment-2](https://user-images.githubusercontent.com/99731766/201311349-bd40443b-2071-45c4-a152-3789c24bb267.png)
### 

Code fix added to the code base
![code-adjustment](https://user-images.githubusercontent.com/99731766/201311473-e70731af-9ede-454e-ba82-0c86582a6f58.png)

**Link to the task given:** https://linear.app/zurichat2/issue/ZUR-119/add-padding-before-the-create-account-link-in-the-login-page
