### PR TITLE
Feat/update channel group spacing

### DIFF
--- a/packages/main/src/components/protected/sidebar/components/Category.jsx
+++ b/packages/main/src/components/protected/sidebar/components/Category.jsx
@@ -56,10 +56,10 @@ export default function Category(props) {
          return Object.values(props.state.sidebar[c]).map((plugin, idx)=>{
  
             
-            return c && c === props.name ? (
+             return c && c === props.name ? (
               <Room
                 isOpen={isOpen}
-                itemName={props.name} 
+                itemName={props.name}
                 id={props.state.sidebar.name}
                 key={index}
                 items={plugin}

--- a/packages/main/src/components/protected/sidebar/styles/Drop.module.css
+++ b/packages/main/src/components/protected/sidebar/styles/Drop.module.css
@@ -85,7 +85,7 @@
 .icon,
 .item__icon {
   /* font-size: 1.2em; */
-  width: 24px;
+  width: unset;
 }
 
 .icon {

--- a/packages/main/src/components/protected/sidebar/styles/Sidebar.module.css
+++ b/packages/main/src/components/protected/sidebar/styles/Sidebar.module.css
@@ -27,7 +27,7 @@
 
 .subCon1 {
   top: 0;
-  position:sticky;
+  position: sticky;
   z-index: 5;
 }
 


### PR DESCRIPTION
issueID =>  ZUR109  
issue Title => update channels group title spacing.
issue desc => channel groups title (the header for the dropdown in the sidebar chat list) should reduce the distance between it and the dropdown arrow

This update was done on the zc_main\packages\main\src\components\protected\sidebar\styles\Drop.module.css file
update includes reducing spacing between the title text and the dropdown arrow icon

=> The first png is a screenshot of the old UI 
=> The second is a screenshot of the new update

In both picture UI was underlined.

![old UI](https://user-images.githubusercontent.com/83684826/201342487-93acd777-f6e6-4345-b491-0060fefddadf.png)
![new UI](https://user-images.githubusercontent.com/83684826/201342791-3228b261-6020-4591-8eb3-1dd458151af0.png)
