### PR TITLE
ZUR-117 move file attach button to the front of the chat box menu options

### DIFF
--- a/packages/ui/src/message-pane-input/components/Toolbar.jsx
+++ b/packages/ui/src/message-pane-input/components/Toolbar.jsx
@@ -197,9 +197,7 @@ const Toolbar = props => {
               {emojiSelect}
             </StyledEmojiSelectWrapper>
           }
-          <UnstyledButton onClick={() => setshowAttachInputBox(true)}>
-            <ClipIcon />
-          </UnstyledButton>
+
           <UnstyledButton onClick={handleClickSendMessage || handleAttachMedia}>
             <SendIcon />
           </UnstyledButton>

--- a/packages/ui/src/message-pane-input/components/Toolbar.jsx
+++ b/packages/ui/src/message-pane-input/components/Toolbar.jsx
@@ -185,6 +185,9 @@ const Toolbar = props => {
           })}
         </FormatContainer>
         <SendContainer>
+          <UnstyledButton onClick={() => setshowAttachInputBox(true)}>
+            <ClipIcon />
+          </UnstyledButton>
           <UnstyledButton>
             <AtIcon />
           </UnstyledButton>


### PR DESCRIPTION
![Screenshot (17)](https://user-images.githubusercontent.com/41517965/201403956-e37c0a7d-c8a9-4e9a-99f4-5d80aab74ad1.png)

the file attach button was moved to the front.