### PR TITLE
Fix the padding issue in the channel name

### DIFF
--- a/packages/ui/src/message-room-view-header/MessageRoomViewHeader.jsx
+++ b/packages/ui/src/message-room-view-header/MessageRoomViewHeader.jsx
@@ -38,7 +38,7 @@ export default function MessageRoomViewHeader(props) {
               className={styles.plugin__header__icon}
             />
           )}
-          <span className={styles.plugin__header__text}>{props.name}</span>
+          <span className={styles.plugin__header__text}>{props.name.split("#").join("# ")}</span>
           <span className={styles.plugin__header__arrow}>
             <MdKeyboardArrowDown />
           </span>

--- a/packages/ui/src/message-room-view-header/message-room-view-header.module.css
+++ b/packages/ui/src/message-room-view-header/message-room-view-header.module.css
@@ -32,7 +32,6 @@
   border-radius: 0.5em;
 }
 .plugin__header__arrow {
-  margin-left: 0.3em;
   font-size: 2.5em;
 }
 .plugin__header__thumbnail {


### PR DESCRIPTION
# Fixes Issue
**My PR Fixes ID-94**

# Changes proposed

## What were you told to do ?
**Fix the padding issue in the channel name**
### Additional Task
**Fix the spacing issue in the channel name**

## What did you do ?
I removed the margin left property that moved the arrow too much from the [CSS file from the message room view header](https://github.com/zurichat/zc_main/blob/dev/packages/ui/src/message-room-view-header/message-room-view-header.module.css) and also updated the displayed output at [the message room view header](https://github.com/zurichat/zc_main/blob/dev/packages/ui/src/message-room-view-header/MessageRoomViewHeader.jsx) so as to give it some spacing
# Check List (Check all the applicable boxes)

- [X] My code follows the code style of this project.
- [X] This PR does not contain plagiarized content.
- [X] The title and description of the PR is clear and explains the approach.
- [X] I am making a pull request against the **dev branch** (left side).
- [X] My commit messages styles matches our requested structure.
- [X] My code additions will fail neither code linting checks nor unit test.
- [X] I am only making changes to files I was requested to.

# Screenshots/ Videos
What the site looked like before 
![Site before changes](https://user-images.githubusercontent.com/116770309/201583596-0f35e907-797e-4a81-98d1-e2b7a9aa9de7.jpg)

After I added my changes
![Site after changes](https://user-images.githubusercontent.com/116770309/201583773-fa220335-bece-4fcd-a4aa-4034c57e2c6d.jpg)
