### PR TITLE
Fix: FE-63/translate zurichat preferences page

### DIFF
--- a/packages/main/src/translations/translation-dictionary/components/Preferences.js
+++ b/packages/main/src/translations/translation-dictionary/components/Preferences.js
@@ -1,177 +1,380 @@
 export default [
-  //side bar for preference menu
   {
     key: "notifications",
     en: "Notifications",
+    de: "Benachrichtigungen",
+    nl: "Meldingen",
+    engb: "Notifications",
     fr: "Notifications",
-    de: "Meldingen"
+    zh: "通知",
+    ar: "إشعارات",
+    es: "Notificaciones",
+    it: "Notifiche",
+    iw: "הודעות",
+    pt: "Notificações"
   },
   {
     key: "message_media",
     en: "Messages and Media",
+    de: "Botschaften und Medien",
+    nl: "Berichten en media",
+    engb: "Messages and Media",
     fr: "Messages et médias",
-    de: "Berichten en Media"
+    zh: "信息和媒体",
+    ar: "الرسائل والوسائط",
+    es: "Mensajes y medios de comunicación",
+    it: "Messaggi e media",
+    iw: "הודעות ומדיה",
+    pt: "Mensagens e Media"
   },
   {
     key: "language_region",
-    en: "Langugage and Region",
+    en: "Language and Region",
+    de: "Sprache und Region",
+    nl: "Taal en regio",
+    engb: "Language and Region",
     fr: "Langue et région",
-    de: "Talen en Regio"
+    zh: "语言和地区",
+    ar: "اللغة والمنطقة",
+    es: "Lengua y región",
+    it: "Lingua e regione",
+    iw: "שפה ואזור",
+    pt: "Língua e Região"
   },
   {
     key: "advanced",
     en: "Advanced Settings",
-    fr: "Réglages avancés",
-    de: "Erweiterte Einstellungen"
+    de: "Erweiterte Einstellungen",
+    nl: "Geavanceerde instellingen",
+    engb: "Advanced Settings",
+    fr: "Paramètres avancés",
+    zh: "高级设置",
+    ar: "الإعدادات المتقدمة",
+    es: "Configuración avanzada",
+    it: "Impostazioni avanzate",
+    iw: "הגדרות מתקדמות",
+    pt: "Configurações avançadas"
   },
-
-  //notification bar in preference menu
-
   {
     key: "notify_me_about",
     en: "Notify Me About",
-    fr: "Avertissez-moi de",
-    de: "Breng me op de hoogte"
+    de: "Benachrichtigen Sie mich über",
+    nl: "Informeer mij over",
+    engb: "Notify Me About",
+    fr: "Informez-moi sur",
+    zh: "通知我关于",
+    ar: "أبلغني عن",
+    es: "Notificarme sobre",
+    it: "Avvisami di",
+    iw: "הודע לי על כך",
+    pt: "Notifique-me sobre"
   },
   {
     key: "notify_all",
     en: "All Messages",
+    de: "Alle Meldungen",
+    nl: "Alle berichten",
+    engb: "All Messages",
     fr: "Tous les messages",
-    de: "Alle berichten"
+    zh: "所有信息",
+    ar: "جميع الرسائل",
+    es: "Todos los mensajes",
+    it: "Tutti i messaggi",
+    iw: "כל ההודעות",
+    pt: "Todas as mensagens"
   },
   {
     key: "notify_dm",
     en: "Direct Messages",
+    de: "Direktnachrichten",
+    nl: "Directe berichten",
+    engb: "Direct Messages",
     fr: "Messages directs",
-    de: "Directe berichten"
+    zh: "直接信息",
+    ar: "رسائل مباشرة",
+    es: "Mensajes directos",
+    it: "Messaggi diretti",
+    iw: "הודעות ישירות",
+    pt: "Mensagens directas"
   },
   {
     key: "notify_nothing",
     en: "Nothing",
+    de: "Nichts",
+    nl: "Niets",
+    engb: "Nothing",
     fr: "Rien",
-    de: "Niks"
+    zh: "没有什么",
+    ar: "لا شيء",
+    es: "Nada",
+    it: "Nulla",
+    iw: "שום דבר",
+    pt: "Nada"
   },
   {
     key: "learn_more_notifications",
     en: "Learn More about notification settings",
+    de: "Erfahren Sie mehr über Benachrichtigungseinstellungen",
+    nl: "Meer informatie over meldingsinstellingen",
+    engb: "Learn More about notification settings",
     fr: "En savoir plus sur les paramètres de notification",
-    de: "Meer informatie over meldingsinstellingen"
+    zh: "了解更多关于通知设置的信息",
+    ar: "تعرف على المزيد حول إعدادات الإشعار",
+    es: "Más información sobre la configuración de las notificaciones",
+    it: "Ulteriori informazioni sulle impostazioni di notifica",
+    iw: "למד עוד אודות הגדרות הודעה",
+    pt: "Saiba mais sobre definições de notificação"
   },
-
-  //lannguages and region
-
   {
     key: "language",
-    en: "Laguage",
+    en: "Language",
+    de: "Sprache",
+    nl: "Taal",
+    engb: "Language",
     fr: "Langue",
-    de: "Taal"
+    zh: "语言",
+    ar: "لغة",
+    es: "Idioma",
+    it: "Lingua",
+    iw: "שפה",
+    pt: "Idioma"
   },
   {
     key: "choose_language",
     en: "Choose the language you want to use in Zurichat.",
+    de: "Wählen Sie die Sprache, die Sie in Zurichat verwenden möchten.",
+    nl: "Kies de taal die u wilt gebruiken in Zurichat.",
+    engb: "Choose the language you want to use in Zurichat.",
     fr: "Choisissez la langue que vous souhaitez utiliser à Zurichat.",
-    de: "Kies de taal die u in Zürichat wilt gebruiken."
+    zh: "选择你想在苏黎世使用的语言。",
+    ar: "اختر اللغة التي تريد استخدامها في Zurichat.",
+    es: "Elija el idioma que desea utilizar en Zurichat.",
+    it: "Scegliete la lingua che volete usare a Zurigo.",
+    iw: "בחר את השפה שבה ברצונך להשתמש ב- Zurichat.",
+    pt: "Escolha a língua que pretende utilizar em Zurique."
   },
   {
     key: "set_timezone",
     en: "Set Time Zone Automatically",
-    fr: "Définir automatiquement le fuseau horaire",
-    de: "Tijdzone automatisch instellen"
+    de: "Zeitzone automatisch einstellen.",
+    nl: "Stel de tijdzone automatisch in.",
+    engb: "Set Time Zone Automatically.",
+    fr: "Régler le fuseau horaire automatiquement.",
+    zh: "自动设置时区。",
+    ar: "حدد المنطقة الزمنية تلقائيًا.",
+    es: "Establecer la zona horaria automáticamente.",
+    it: "Impostazione automatica del fuso orario.",
+    iw: "הגדר אזור זמן באופן אוטומטי.",
+    pt: "Definir fuso horário automaticamente."
   },
   {
     key: "timezone",
     en: "Timezone",
+    de: "Zeitzone",
+    nl: "Tijdzone",
+    engb: "Timezone",
     fr: "Fuseau horaire",
-    de: "Tijdzone"
+    zh: "时区",
+    ar: "منطقة زمنية",
+    es: "Zona horaria",
+    it: "Fuso orario",
+    iw: "אזור זמן",
+    pt: "Fuso horário"
   },
   {
     key: "timezone_info",
     en: "Zurichat uses your time zone to send summary and notification emails, for times in your activity feeds and for reminders",
-    fr: "Zurichat utilise votre fuseau horaire pour envoyer des e-mails de résumé et de notification, pour les heures dans vos flux d'activité et pour les rappels",
-    de: "Zurichat gebruikt uw tijdzone om overzichts- en notificatie-e-mails te verzenden, voor tijden in uw activiteitenfeeds en voor herinneringen"
+    de: "Zurichat verwendet Ihre Zeitzone für den Versand von Zusammenfassungs- und Benachrichtigungs-E-Mails, für Zeiten in Ihren Aktivitäts-Feeds und für Erinnerungen",
+    nl: "Zurichat gebruikt uw tijdzone om overzichts- en kennisgevingse-mails te sturen, voor tijden in uw activiteitenfeeds en voor herinneringen.",
+    engb: "Zurichat uses your time zone to send summary and notification emails, for times in your activity feeds and for reminders",
+    fr: "Zurichat utilise votre fuseau horaire pour envoyer des courriels de résumé et de notification, pour les heures dans vos flux d'activités et pour les rappels.",
+    zh: "Zurichat使用您的时区来发送摘要和通知邮件，用于您活动资料中的时间和提醒",
+    ar: "يستخدم Zurichat منطقتك الزمنية لإرسال رسائل البريد الإلكتروني الملخصة والإخطار، للأوقات في خلاصات نشاطك وللتذكيرات",
+    es: "Zurichat utiliza su zona horaria para enviar correos electrónicos de resumen y notificación, para las horas en sus feeds de actividad y para los recordatorios",
+    it: "Zurichat utilizza il vostro fuso orario per inviare e-mail di riepilogo e di notifica, per gli orari nei vostri feed di attività e per i promemoria.",
+    iw: "Zurichat משתמש באזור הזמן שלך כדי לשלוח הודעות דואר אלקטרוני של סיכום והודעות, עבור זמנים בהזנות הפעילות ועבור תזכורות",
+    pt: "A Zurichat utiliza o seu fuso horário para enviar e-mails de resumo e notificação, para horários nos seus feeds de actividade e para lembretes"
   },
-  //plugin advanced settings
   {
     key: "plugins",
     en: "Change options specific to plugins in this workspace.",
-    fr: "Modifiez les options spécifiques aux plugins dans cet espace de travail.",
-    de: "Wijzig opties die specifiek zijn voor plug-ins in deze werkruimte."
+    de: "Ändern Sie die Optionen für die Plugins in diesem Arbeitsbereich.",
+    nl: "Wijzig opties die specifiek zijn voor plugins in deze werkruimte.",
+    engb: "Change options specific to plugins in this workspace.",
+    fr: "Modifier les options spécifiques aux plugins dans cet espace de travail.",
+    zh: "在这个工作区改变特定于插件的选项。",
+    ar: "قم بتغيير الخيارات الخاصة بالملحقات في مساحة العمل هذه.",
+    es: "Cambiar las opciones específicas de los plugins en este espacio de trabajo.",
+    it: "Modifica le opzioni specifiche dei plugin in questo spazio di lavoro.",
+    iw: "שנה אפשרויות ספציפיות ל תוספים בסביבת עבודה זו.",
+    pt: "Alterar opções específicas para plugins neste espaço de trabalho."
   },
   {
     key: "plugin_options",
     en: "Plugin Options",
-    fr: "Options de plug-in",
-    de: "Plugin-opties"
+    de: "Plugin-Optionen",
+    nl: "Plugin Opties",
+    engb: "Plugin Options",
+    fr: "Options du plugin",
+    zh: "插件选项",
+    ar: "خيارات CPlugin",
+    es: "Opciones de los plugins",
+    it: "Opzioni del plugin",
+    iw: "אפשרויות תוסף",
+    pt: "Opções de Plugin"
   },
   {
     key: "no_options",
     en: "No options available",
+    de: "Keine Optionen verfügbar",
+    nl: "Geen opties beschikbaar",
+    engb: "No options available",
     fr: "Aucune option disponible",
-    de: "Geen opties beschikbaar"
+    zh: "没有可用的选项",
+    ar: "لا توجد خيارات متاحة",
+    es: "No hay opciones disponibles",
+    it: "Nessuna opzione disponibile",
+    iw: "אין אפשרויות זמינות",
+    pt: "Não há opções disponíveis"
   },
-
-  //messages and media
-
   {
     key: "messages",
     en: "Messages",
+    de: "Nachrichten",
+    nl: "Berichten",
+    engb: "Messages",
     fr: "Messages",
-    de: "Berichten"
+    zh: "留言",
+    ar: "رسائل",
+    es: "Mensajes",
+    it: "Messaggi",
+    iw: "הודעות",
+    pt: "Mensagens"
   },
   {
     key: "names",
     en: "Name",
+    de: "Name",
+    nl: "Naam",
+    engb: "Name",
     fr: "Nom",
-    de: "Naam"
+    zh: "命名",
+    ar: "اسم",
+    es: "Nombre",
+    it: "Nome",
+    iw: "שם",
+    pt: "Nome"
   },
   {
     key: "full_names",
     en: "Full & display names",
-    fr: "Noms complets et à afficher",
-    de: "Volledige en weergegeven namen"
+    de: "Vollständige und angezeigte Namen",
+    nl: "Volledige & weergavenamen",
+    engb: "Full & display names",
+    fr: "Noms complets et noms d'affichage",
+    zh: "全名和显示名称",
+    ar: "أسماء كاملة وعرض",
+    es: "Nombres completos y para mostrar",
+    it: "Nomi completi e nomi visualizzati",
+    iw: "שמות מלאים ושמות תצוגה",
+    pt: "Nomes completos e de exibição"
   },
   {
     key: "display_names",
     en: "Just display names",
-    fr: "Erweiterte Einstellungen",
-    de: "Geef gewoon namen weer"
+    de: "Nur Namen anzeigen",
+    nl: "Gewoon namen weergeven",
+    engb: "Just display names",
+    fr: "Juste des noms d'affichage",
+    zh: "只是显示名称",
+    ar: "فقط عرض الأسماء",
+    es: "Sólo mostrar los nombres",
+    it: "Solo nomi di visualizzazione",
+    iw: "פשוט הצג שמות",
+    pt: "Basta exibir nomes"
   },
-
   {
     key: "change_display_name",
     en: "To change your full or display name, go to",
-    fr: "Pour modifier votre nom complet ou d'affichage, accédez à",
-    de: "Ga naar om uw volledige naam of weergavenaam te wijzigen"
+    de: "Um Ihren vollständigen oder angezeigten Namen zu ändern, gehen Sie zu",
+    nl: "Om uw volledige naam of weergavenaam te wijzigen, gaat u naar",
+    engb: "To change your full or display name, go to",
+    fr: "Pour modifier votre nom complet ou votre nom d'affichage, allez à l'adresse suivante",
+    zh: "要改变你的全名或显示名称，请到",
+    ar: "لتغيير اسمك الكامل أو العرض، انتقل إلى",
+    es: "Para cambiar su nombre completo o de presentación, vaya a",
+    it: "Per modificare il nome completo o il nome visualizzato, andare su",
+    iw: "כדי לשנות את שם התצוגה המלא או המלא שלך, עבור אל",
+    pt: "Para alterar o seu nome completo ou exibir o seu nome, vá para"
   },
   {
     key: "your_profile",
     en: "your profile",
+    de: "Ihr Profil",
+    nl: "uw profiel",
+    engb: "your profile",
     fr: "votre profil",
-    de: "jouw profiel"
+    zh: "你的资料",
+    ar: "ملفك الشخصي",
+    es: "su perfil",
+    it: "il tuo profilo",
+    iw: "הפרופיל שלך",
+    pt: "o seu perfil"
   },
   {
     key: "emoji",
     en: "Emoji",
-    fr: "Émoji",
-    de: "Emoji"
+    de: "Emoji",
+    nl: "Emoji",
+    engb: "Emoji",
+    fr: "Emoji",
+    zh: "表情符号",
+    ar: "رمز تعبيري",
+    es: "Emoji",
+    it: "Emoji",
+    iw: 'אימוג"י',
+    pt: "Emoji"
   },
   {
     key: "skin_tone",
     en: "Default Skin Tone",
-    fr: "Ton de peau par défaut",
-    de: "Standaard huidskleur"
+    de: "Standard-Hautton",
+    nl: "Standaard huidskleur",
+    engb: "Default Skin Tone",
+    fr: "Teinte de peau par défaut",
+    zh: "默认的皮肤色调",
+    ar: "لون البشرة الافتراضي",
+    es: "Tono de piel por defecto",
+    it: "Tonalità della pelle predefinita",
+    iw: "גוון מעטפת ברירת מחדל",
+    pt: "Tom de Pele por Defeito"
   },
   {
     key: "choose_skin",
     en: "Choose the default skin tone that will be used whenever you use certain emojis in",
-    fr: "Choisissez le teint par défaut qui sera utilisé chaque fois que vous utiliserez certains emojis dans",
-    de: "Kies de standaard huidskleur die wordt gebruikt wanneer u bepaalde emoji's gebruikt"
+    de: "Wählen Sie den Standard-Hautton, der verwendet wird, wenn Sie bestimmte Emojis in",
+    nl: "Kies de standaard huidskleur die wordt gebruikt wanneer u bepaalde emoji's gebruikt in",
+    engb: "Choose the default skin tone that will be used whenever you use certain emojis in",
+    fr: "Choisissez la couleur de peau par défaut qui sera utilisée lorsque vous utiliserez certains emojis dans l'interface utilisateur.",
+    zh: "选择默认的肤色，当你使用某些表情符号时，将使用该肤色。",
+    ar: "اختر لون البشرة الافتراضي الذي سيتم استخدامه كلما استخدمت بعض الرموز التعبيرية فيه",
+    es: "Elige el tono de piel por defecto que se utilizará cada vez que uses ciertos emojis en",
+    it: "Scegliete la tonalità della pelle predefinita che verrà utilizzata ogni volta che userete certe emoji in",
+    iw: "בחר את גוון העור המהווה ברירת מחדל שישמש בכל פעם שאתה משתמש בצליל מוג'יס מסוים ב-",
+    pt: "Escolha o tom de pele padrão que será usado sempre que utilizar certos emojis em"
   },
-
   {
     key: "reactions_messages",
     en: "Reactions and messages",
+    de: "Reaktionen und Meldungen",
+    nl: "Reacties en berichten",
+    engb: "Reactions and messages",
     fr: "Réactions et messages",
-    de: "Reacties en berichten"
+    zh: "反应和信息",
+    ar: "ردود الفعل والرسائل",
+    es: "Reacciones y mensajes",
+    it: "Reazioni e messaggi",
+    iw: "תגובות והודעות",
+    pt: "Reacções e mensagens"
   }
 ];


### PR DESCRIPTION
https://linear.app/team-mallet/issue/FE-63/translate-zurichat-preferences-page

#FE/63

My PR Fixes FE-63/translate zurichat preferences page

# Changes proposed

## What were you told to do?
Translate zurichat preferences page.

## What did you do?
I added key map values for other languages on the preferences page and the other side bars, and added functionality to make hebrew and arabic texts start from left to right

# Check List (Check all the applicable boxes)

- [X] My code follows the code style of this project.
- [X] This PR does not contain plagiarized content.
- [X] The title and description of the PR is clear and explains the approach.
- [X] I am making a pull request against the **dev branch** (left side).
- [X] My commit messages styles matches our requested structure.
- [X] My code additions will fail neither code linting checks nor unit test.
- [X] I am only making changes to files I was requested to.

# Screenshots/ Videos

A section of preference page with Arabic language
<img width="1117" alt="preferencesArabic" src="https://user-images.githubusercontent.com/97551755/204112658-4e8c00a1-f9e8-4944-aad1-fda0fc9ad420.png">

A section of preference page with Hebrew language
<img width="1117" alt="preferencesHebrews" src="https://user-images.githubusercontent.com/97551755/204112662-165c3013-bc7b-442b-87a8-aa68a16508de.png">

A section of preference page with English language
<img width="1117" alt="preferencesEnglish" src="https://user-images.githubusercontent.com/97551755/204112671-7f3f7500-9a47-4ee4-80e3-97c501747cbe.png">

A screenshot of the translation code in preferences.js file
<img width="1117" alt="preferencesCodeTranslate" src="https://user-images.githubusercontent.com/97551755/204112684-62a3450f-3129-4917-b4ca-62a6211d559b.png">



