### PR TITLE
minor UI adjustments on zc_main plugin load section

### DIFF
--- a/packages/main/src/pages/protected/workspace/Workspace.style.js
+++ b/packages/main/src/pages/protected/workspace/Workspace.style.js
@@ -47,5 +47,7 @@ export const WorkspaceWrapperStyle = styled.div`
   & > #zuri-plugin-load-section {
     height: 100%;
     width: 100%;
+    display: flex;
+    flex-direction: column;
   }
 `;

--- a/packages/ui/src/message-board/MessageBoard.styled.js
+++ b/packages/ui/src/message-board/MessageBoard.styled.js
@@ -3,7 +3,7 @@ import styled from "styled-components";
 export const MessageBoardContainer = styled.section`
   display: flex;
   width: 100%;
-  height: ${props => props.height};
+  height: 100%;
   gap: 8px;
   flex-direction: column;
 


### PR DESCRIPTION
<!-- Do not delete this PR template. Just edit it to include the required information -->

# Fixes Issue/Linear Ticket

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->
( This could be an existing issue or a linear ticket )
<!-- Github Issue Example: Closes #31 -->
<!-- Linear Ticket Example: Fixes ID-221 -->

**My PR Closes #issue_number_here** or
**My PR Fixes ID-linear_ticket_number_here**

# Changes proposed

## What were you told to do?
Fix missing header in the chat area

## What did you do?
Gave the zuri main plugin load section a display of flex and a flex direction of column to allow its contents flow from top to bottom.
changed the Message Board container height to 100% allowing it to take up the available space. The calculated height that was in place was done with javascript using the screen's view height. When new items suddenly appear in the dom, the calculated height doesn't adjust and thereby displaces some items that do not fit into the available space



# Check List (Check all the applicable boxes)

🚨Please review the [style guide for contributing](https://github.com/zurichat/zc_main/blob/dev/docs/STYLING.md) and [guidelines for contributing](https://github.com/zurichat/zc_main/blob/dev/docs/CONTRIBUTING.md) to this repository.

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [] My code follows the code style of this project.
- [] This PR does not contain plagiarized content.
- [] The title and description of the PR is clear and explains the approach.
- [] I am making a pull request against the **dev branch** (left side).
- [] My commit messages styles matches our requested structure.
- [] My code additions will fail neither code linting checks nor unit test.
- [] I am only making changes to files I was requested to.

# Screenshots/ Videos

<!-- If the changes are static page changes or UI changes add screenshots -->
<!-- If the changes involve implementing a functionality or working with apis, include a video 
detailing how to implement the functionality and the request to the api and responses from the api endpoint-->
<!-- Add all the screenshots/videos which support your changes i.e before your change and after your change -->