### PR TITLE
fix: sidebar resizing and workspace switching

### DIFF
--- a/packages/main/src/components/protected/extra-sidebar/index.js
+++ b/packages/main/src/components/protected/extra-sidebar/index.js
@@ -24,7 +24,6 @@ export default function ExtraSidebar() {
 
     if (mounting)
       getWorkspaces().then(response => {
-        console.log("response here", response);
         setWorkspaces(() => response);
       });
 
@@ -161,12 +160,3 @@ const getAcronymn = sentence => {
   let acronym = matches.join("");
   return acronym;
 };
-
-// const switchWorkspace = id => {
-//   const currentPlugin = localStorage.getItem("currentPlugin") || "plugin-chat";
-//   const currentPluginRoom = localStorage.getItem("currentRoom") || "";
-//   const defaultPluginRoom = `${currentPlugin}/${currentPluginRoom}`;
-
-//   window.location.href = `/workspace/${id}/${defaultPluginRoom}`;
-//   history.replace(`/workspace/${id}/plugin-chat/`);
-// };

--- a/packages/main/src/components/protected/extra-sidebar/index.js
+++ b/packages/main/src/components/protected/extra-sidebar/index.js
@@ -1,0 +1,162 @@
+import axios from "axios";
+import { setupCache } from "axios-cache-adapter";
+import { BASE_API_URL } from "@zuri/utilities";
+import {
+  BsFillCaretDownFill,
+  BsFillQuestionCircleFill,
+  BsGearFill,
+  BsPlusCircle
+} from "react-icons/bs";
+import { Link } from "react-router-dom";
+import { useState, useEffect } from "react";
+
+export default function ExtraSidebar() {
+  const [workspaces, setWorkspaces] = useState([]);
+  console.log("Got to render this");
+
+  useEffect(() => {
+    let mounting = true;
+
+    if (mounting)
+      getWorkspaces().then(response => {
+        console.log("response here", response);
+        setWorkspaces(() => response);
+      });
+
+    return () => {
+      mounting = false;
+    };
+  }, []);
+
+  console.log("workspaces length", workspaces.length);
+
+  return workspaces.length ? (
+    <>
+      <div className="x-sb_workspaceBox">
+        {workspaces?.map((workSpace, index) => (
+          <div
+            className="x-sb_workspaceWrap"
+            role="button"
+            key={index}
+            title={workSpace.name}
+          >
+            <div
+              className={`${
+                window.location.pathname.includes(workSpace.short_id)
+                  ? "x-sb_currentWorkspace"
+                  : "x-sb_workspaceAvatar"
+              }`}
+              role="button"
+              // onClick={() => switchWorkspace(short_id)}
+              onClick={() => switchWorkspace(workSpace.short_id)}
+              title={workSpace.name}
+            >
+              <div className="x-sb_workspaceAvatarM">
+                {getAcronymn(workSpace.name)}
+              </div>
+            </div>
+            <div className="x-sb_workspaceInfo">
+              <div>
+                <h3 className="x-sb_workspaceName">{workSpace.name}</h3>
+                <p>{workSpace.workspace_url}</p>
+              </div>
+              <BsFillCaretDownFill />
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="x-sb_lowerDrawer">
+        <Link
+          to="/choose-workspace"
+          className="x-sb_workspaceAdd"
+          role="button"
+          title="Add a workspace"
+        >
+          <div className="x-sb_workspacehelp">
+            <BsPlusCircle />
+          </div>
+          <p className="x-sb_optionName">Add a workspace</p>
+        </Link>
+        <div className="x-sb_workspaceAdd" role="button" title="Preferences">
+          <div className="x-sb_workspacehelp">
+            <BsGearFill />
+          </div>
+          <p className="x-sb_optionName">Preferences</p>
+        </div>
+        <div className="x-sb_workspaceAdd" role="button" title="Help">
+          <div className="x-sb_workspacehelp">
+            <BsFillQuestionCircleFill />
+          </div>
+          <p className="x-sb_optionName">Help</p>
+        </div>
+      </div>
+    </>
+  ) : null;
+}
+
+const cache = setupCache({
+  // check if response header has a specification for caching
+  readHeaders: true,
+  // if not, cache API response for 3 minutes
+  maxAge: 3 * 60 * 1000,
+  // {debug: true} logs caching info to console.
+  debug: false
+});
+
+const instance = axios.create({
+  adapter: cache.adapter
+});
+
+async function getWorkspaces() {
+  let userData = JSON.parse(sessionStorage.getItem("user"));
+
+  if (userData) {
+    let response = await instance.get(
+      `${BASE_API_URL}/users/${userData.email}/organizations`,
+      {
+        headers: {
+          Authorization: `Bearer ${userData.token}`
+        }
+      }
+    );
+
+    const workspaces = response.data.data;
+    sessionStorage.setItem("organisations", JSON.stringify(workspaces));
+
+    addShortIds(workspaces);
+    return workspaces;
+  }
+}
+
+function addShortIds(workspaces) {
+  const urlsTracker = { workspaceIds: [] };
+
+  workspaces.map(workspace => {
+    urlsTracker.workspaceIds.push({
+      real_id: workspace.id,
+      short_id: `${workspace.id.slice(4, 6)}${workspace.id.slice(
+        6,
+        8
+      )}${workspace.id.slice(-3, -1)}`
+    });
+
+    localStorage.setItem("urlsTracker", JSON.stringify(urlsTracker));
+
+    workspace["short_id"] = urlsTracker.workspaceIds.filter(
+      urlId => urlId.real_id === workspace.id
+    )[0]?.short_id;
+    return workspace;
+  });
+}
+
+const getAcronymn = sentence => {
+  let matches = sentence.match(/\b(\w)/g); // ['J','S','O','N']
+  let acronym = matches.join("");
+  return acronym;
+};
+
+const switchWorkspace = id => {
+  console.log(id);
+  window.location.href = `/workspace/${id}/plugin-chat/all-dms`;
+  history.replace(`/workspace/${id}/plugin-chat/`);
+};

--- a/packages/main/src/components/protected/extra-sidebar/index.js
+++ b/packages/main/src/components/protected/extra-sidebar/index.js
@@ -7,12 +7,17 @@ import {
   BsGearFill,
   BsPlusCircle
 } from "react-icons/bs";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { useState, useEffect } from "react";
 
 export default function ExtraSidebar() {
+  const { pathname } = useLocation();
   const [workspaces, setWorkspaces] = useState([]);
-  console.log("Got to render this");
+  const currentPlugin = localStorage.getItem("currentPlugin") || "plugin-chat";
+  const currentPluginRoom = localStorage.getItem("currentRoom") || "";
+  const defaultPluginRoom = `${currentPlugin}/${currentPluginRoom}`;
+
+  const isActive = id => pathname.includes(id);
 
   useEffect(() => {
     let mounting = true;
@@ -28,8 +33,6 @@ export default function ExtraSidebar() {
     };
   }, []);
 
-  console.log("workspaces length", workspaces.length);
-
   return workspaces.length ? (
     <>
       <div className="x-sb_workspaceBox">
@@ -40,21 +43,21 @@ export default function ExtraSidebar() {
             key={index}
             title={workSpace.name}
           >
-            <div
+            <Link
+              to={`/workspace/${workSpace.short_id}/${defaultPluginRoom}`}
               className={`${
-                window.location.pathname.includes(workSpace.short_id)
+                isActive(workSpace.short_id)
                   ? "x-sb_currentWorkspace"
                   : "x-sb_workspaceAvatar"
               }`}
               role="button"
-              // onClick={() => switchWorkspace(short_id)}
-              onClick={() => switchWorkspace(workSpace.short_id)}
+              // onClick={() => switchWorkspace(workSpace.short_id)}
               title={workSpace.name}
             >
               <div className="x-sb_workspaceAvatarM">
                 {getAcronymn(workSpace.name)}
               </div>
-            </div>
+            </Link>
             <div className="x-sb_workspaceInfo">
               <div>
                 <h3 className="x-sb_workspaceName">{workSpace.name}</h3>
@@ -120,18 +123,20 @@ async function getWorkspaces() {
       }
     );
 
+    let parsedWorkspaces = [];
     const workspaces = response.data.data;
     sessionStorage.setItem("organisations", JSON.stringify(workspaces));
 
-    addShortIds(workspaces);
-    return workspaces;
+    parsedWorkspaces = addShortIds(workspaces);
+    return parsedWorkspaces;
   }
 }
 
 function addShortIds(workspaces) {
+  let parsedWorkspaces = [];
   const urlsTracker = { workspaceIds: [] };
 
-  workspaces.map(workspace => {
+  parsedWorkspaces = workspaces.map(workspace => {
     urlsTracker.workspaceIds.push({
       real_id: workspace.id,
       short_id: `${workspace.id.slice(4, 6)}${workspace.id.slice(
@@ -147,6 +152,8 @@ function addShortIds(workspaces) {
     )[0]?.short_id;
     return workspace;
   });
+
+  return parsedWorkspaces;
 }
 
 const getAcronymn = sentence => {
@@ -155,8 +162,11 @@ const getAcronymn = sentence => {
   return acronym;
 };
 
-const switchWorkspace = id => {
-  console.log(id);
-  window.location.href = `/workspace/${id}/plugin-chat/all-dms`;
-  history.replace(`/workspace/${id}/plugin-chat/`);
-};
+// const switchWorkspace = id => {
+//   const currentPlugin = localStorage.getItem("currentPlugin") || "plugin-chat";
+//   const currentPluginRoom = localStorage.getItem("currentRoom") || "";
+//   const defaultPluginRoom = `${currentPlugin}/${currentPluginRoom}`;
+
+//   window.location.href = `/workspace/${id}/${defaultPluginRoom}`;
+//   history.replace(`/workspace/${id}/plugin-chat/`);
+// };

--- a/packages/main/src/components/protected/sidebar/components/Sidebar.jsx
+++ b/packages/main/src/components/protected/sidebar/components/Sidebar.jsx
@@ -29,7 +29,7 @@ const Sidebar = props => {
 
   const sidebarRef = useRef(null);
   const [isResizing, setIsResizing] = useState(false);
-  const [sidebarWidth, setSidebarWidth] = useState(260);
+  const [sidebarWidth, setSidebarWidth] = useState(400);
 
   const startResizing = useCallback(() => {
     setIsResizing(true);
@@ -198,7 +198,7 @@ const Sidebar = props => {
       ref={sidebarRef}
       style={{ width: sidebarWidth }}
       onMouseDown={e => e.preventDefault()}
-      className={`container-fluid ${styles.sb__container}`}
+      className={`${styles.sb__container}`}
     >
       {sidebarWidth > 0 && (
         <div className={styles.sb__content}>

--- a/packages/main/src/components/protected/sidebar/components/Sidebar.jsx
+++ b/packages/main/src/components/protected/sidebar/components/Sidebar.jsx
@@ -29,7 +29,7 @@ const Sidebar = props => {
 
   const sidebarRef = useRef(null);
   const [isResizing, setIsResizing] = useState(false);
-  const [sidebarWidth, setSidebarWidth] = useState(400);
+  const [sidebarWidth, setSidebarWidth] = useState(250);
 
   const startResizing = useCallback(() => {
     setIsResizing(true);
@@ -55,7 +55,7 @@ const Sidebar = props => {
         document.querySelector("body").style.cursor = "col-resize";
 
         // collapse the sidebar on further minimization
-        if (newWidth <= 195) setSidebarWidth(0);
+        if (newWidth <= 230) setSidebarWidth(0);
       }
     },
     [isResizing]

--- a/packages/main/src/components/protected/sidebar/styles/Sidebar.module.css
+++ b/packages/main/src/components/protected/sidebar/styles/Sidebar.module.css
@@ -9,7 +9,7 @@
   padding: 0;
   display: flex;
   min-width: 6px;
-  max-width: 300px;
+  max-width: 400px;
   overflow-y: scroll;
   scroll-behavior: smooth;
   -ms-overflow-style: none;

--- a/packages/main/src/pages/protected/workspace/Workspace.jsx
+++ b/packages/main/src/pages/protected/workspace/Workspace.jsx
@@ -1,9 +1,5 @@
-import { BASE_API_URL } from "@zuri/utilities";
-import axios from "axios";
-import { setupCache } from "axios-cache-adapter";
 import { useEffect, useState } from "react";
 import {
-  Link,
   Route,
   Switch,
   useHistory,
@@ -12,8 +8,8 @@ import {
 } from "react-router-dom";
 import LiveBroadcast from "../../../components/media-chat/LiveBroadcast";
 import useParamHook from "./useParamHook";
-import styles from "./Workspace.module.css";
 import {
+  ExtraSidebarWrapperStyle,
   GlobalWorkSpaceStyle,
   SidebarWrapperStyle,
   TopBarWrapperStyle,
@@ -22,29 +18,10 @@ import {
 
 // import { GeneralLoading } from "../../../components";
 
-import { useMediaQuery } from "@chakra-ui/react";
-import {
-  BsFillCaretDownFill,
-  BsFillQuestionCircleFill,
-  BsGearFill,
-  BsPlusCircle
-} from "react-icons/bs";
 import VideoChat from "../../../components/media-chat/VideoChat";
 import VoiceCall from "../../../components/media-chat/VoiceCall/VoiceCall";
 import { Sidebar, TopBar } from "../../../components/protected";
-
-const cache = setupCache({
-  // check if response header has a specification for caching
-  readHeaders: true,
-  // if not, cache API response for 3 minutes
-  maxAge: 3 * 60 * 1000,
-  // {debug: true} logs caching info to console.
-  debug: false
-});
-
-const instance = axios.create({
-  adapter: cache.adapter
-});
+import ExtraSidebar from "../../../components/protected/extra-sidebar";
 
 export default function Index() {
   // const { workspaceId } = useParams();
@@ -52,67 +29,25 @@ export default function Index() {
     workspaceId: { workspaceId, short_id }
   } = useParamHook({ workspaceId: "workspaceId" });
 
-  const [tablet] = useMediaQuery("(max-width: 769px");
-
   const location = useLocation();
   // console.log(location)
   const history = useHistory();
   const match = useRouteMatch(`/workspace/${short_id}`);
   const pluginsName = ["plugin-music"];
-  const [workspaces, setWorkspaces] = useState([]);
   const [sidebarOpen, setSidebarOpen] = useState(false);
-
-  const switchWorkspace = id => {
-    console.log(id);
-    window.location.href = `/workspace/${id}/plugin-chat/all-dms`;
-    history.replace(`/workspace/${id}/plugin-chat/`);
-  };
-
-  const getAcronymn = sentence => {
-    let matches = sentence.match(/\b(\w)/g); // ['J','S','O','N']
-    let acronym = matches.join("");
-    return acronym;
-  };
-
-  const fetchUserWorkspacesResponse = async () => {
-    let userData = JSON.parse(sessionStorage.getItem("user"));
-
-    if (userData) {
-      let response = await instance.get(
-        `${BASE_API_URL}/users/${userData.email}/organizations`,
-        {
-          headers: {
-            Authorization: `Bearer ${userData.token}`
-          }
-        }
-      );
-
-      const userSpace = response.data.data;
-      const urlsTracker = JSON.parse(localStorage.getItem("urlsTracker"));
-
-      const newUserSpace = [];
-      userSpace.forEach(spaceUser => {
-        const current = urlsTracker.workspaceIds.filter(
-          urlId => urlId.real_id === spaceUser.id
-        );
-        spaceUser["short_id"] = current[0].short_id;
-        newUserSpace.push(spaceUser);
-      });
-
-      setWorkspaces(newUserSpace);
-    }
-  };
 
   useEffect(() => {
     window.dispatchEvent(new Event("zuri-plugin-load"));
     match?.isExact &&
       history.replace(`/workspace/${short_id}/plugin-chat/all-dms`);
   }, []);
+
   // Temporary
   useEffect(() => {
     localStorage.setItem("currentWorkspace", workspaceId);
     localStorage.setItem("currentWorkspaceShort", short_id);
   }, [workspaceId]);
+
   useEffect(() => {
     window.localStorage.setItem("lastLocation", location.pathname);
     const activePlugin = pluginsName.find(plugin =>
@@ -125,9 +60,6 @@ export default function Index() {
       )} | ${localStorage.getItem("orgName")}`;
     }
   }, [location.pathname]);
-  useEffect(() => {
-    fetchUserWorkspacesResponse();
-  }, []);
 
   const toggleSidebar = () => {
     setSidebarOpen(!sidebarOpen);
@@ -144,89 +76,15 @@ export default function Index() {
         style={{ display: "flex", height: "calc(100vh - 48px)" }}
         id="workspace-all"
       >
-        {/* only show extra side bar if (workspaces.length > 1) */}
-        {workspaces && workspaces.length > 1 && (
-          <div
-            id={`${styles.workspaceSidebar}`}
-            {...(tablet &&
-              !sidebarOpen && {
-                className: styles.workspaceSidebarClosed
-              })}
-          >
-            <div id={`${styles.workspaceBox}`}>
-              {/* {workspaces} */}
-              {workspaces?.map((workSpace, index) => (
-                <div
-                  className={`${styles.workspaceWrap}`}
-                  role="button"
-                  key={index}
-                  title={workSpace.name}
-                >
-                  <div
-                    className={`${
-                      window.location.pathname.includes(workSpace.short_id)
-                        ? styles.currentWorkspace
-                        : styles.workspaceAvatar
-                    }`}
-                    role="button"
-                    // onClick={() => switchWorkspace(short_id)}
-                    onClick={() => switchWorkspace(workSpace.short_id)}
-                    title={workSpace.name}
-                  >
-                    <div className={`${styles.workspaceAvatarM}`}>
-                      {getAcronymn(workSpace.name)}
-                    </div>
-                  </div>
-                  <div className={`${styles.workspaceInfo}`}>
-                    <div>
-                      <h3 className={`${styles.workspaceName}`}>
-                        {workSpace.name}
-                      </h3>
-                      <p>{workSpace.workspace_url}</p>
-                    </div>
-                    <BsFillCaretDownFill />
-                  </div>
-                </div>
-              ))}
-            </div>
-            <div className={`${styles.lowerDrawer}`}>
-              <Link
-                to="/choose-workspace"
-                className={`${styles.workspaceAdd}`}
-                role="button"
-                title="Add a workspace"
-              >
-                <div className={`${styles.workspacehelp}`}>
-                  <BsPlusCircle />
-                </div>
-                <p className={`${styles.optionName}`}>Add a workspace</p>
-              </Link>
-              <div
-                className={`${styles.workspaceAdd}`}
-                role="button"
-                title="Preferences"
-              >
-                <div className={`${styles.workspacehelp}`}>
-                  <BsGearFill />
-                </div>
-                <p className={`${styles.optionName}`}>Preferences</p>
-              </div>
-              <div
-                className={`${styles.workspaceAdd}`}
-                role="button"
-                title="Help"
-              >
-                <div className={`${styles.workspacehelp}`}>
-                  <BsFillQuestionCircleFill />
-                </div>
-                <p className={`${styles.optionName}`}>Help</p>
-              </div>
-            </div>
-          </div>
-        )}
-        <SidebarWrapperStyle>
-          <Sidebar />
-        </SidebarWrapperStyle>
+        <>
+          <ExtraSidebarWrapperStyle open={sidebarOpen}>
+            <ExtraSidebar />
+          </ExtraSidebarWrapperStyle>
+          <SidebarWrapperStyle>
+            <Sidebar />
+          </SidebarWrapperStyle>
+        </>
+
         <WorkspaceWrapperStyle>
           <div id="zuri-plugin-load-section"></div>
           <Switch>

--- a/packages/main/src/pages/protected/workspace/Workspace.style.js
+++ b/packages/main/src/pages/protected/workspace/Workspace.style.js
@@ -20,9 +20,7 @@ export const TopBarWrapperStyle = styled.div`
 `;
 
 export const SidebarWrapperStyle = styled.div`
-  width: 100%;
-  max-width: 260px;
-  min-width: 230px;
+  flex: 0;
   height: 100%;
   -ms-overflow-style: none;
   scrollbar-width: none;
@@ -36,6 +34,7 @@ export const SidebarWrapperStyle = styled.div`
 `;
 
 export const WorkspaceWrapperStyle = styled.div`
+  position: relative;
   flex: 1;
   height: 100%;
   background-color: var(--bg-color);
@@ -46,5 +45,127 @@ export const WorkspaceWrapperStyle = styled.div`
     display: flex;
     flex-direction: column;
     position: relative;
+  }
+`;
+
+export const ExtraSidebarWrapperStyle = styled.div`
+  height: 95vh;
+  background: #007b53;
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid #007b53;
+  transition: all 0.2s;
+
+  & .x-sb_workspaceBox {
+    height: 75%;
+    padding: 0 10px;
+  }
+
+  & .x-sb_workspaceInfo {
+    display: flex;
+    width: 100%;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  & .x-sb_workspaceWrap {
+    display: flex;
+    align-items: flex-end;
+    gap: 8px;
+
+    &:first-child {
+      margin-top: 12px;
+    }
+
+    & h3,
+    & p {
+      margin-bottom: 0;
+      padding: 0;
+      line-height: 20px;
+    }
+
+    & p {
+      @media (max-width: 426px) {
+        font-size: 12px;
+      }
+    }
+  }
+
+  & .x-sb_workspaceAvatar {
+    border-radius: 10px;
+    border: 3px solid transparent;
+    text-align: center;
+    margin-bottom: 5px;
+    padding: 0.5px;
+
+    &:hover {
+      border: 3px solid #dddddd;
+    }
+  }
+
+  & .x-sb_workspaceAvatarM {
+    height: 40px;
+    width: 40px;
+    border-radius: 6px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: rgb(69, 64, 64);
+    color: #fff;
+    text-transform: uppercase;
+  }
+
+  & .x-sb_currentWorkspace {
+    border-radius: 5px;
+    border: 2px solid rgb(216, 248, 239);
+    text-align: center;
+    margin-bottom: 5px;
+    padding: 0.5px;
+  }
+
+  & .x-sb_workspaceAdd {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    text-align: center;
+    padding: 10px 20px 0 20px;
+  }
+
+  & .x-sb_workspaceAdd svg {
+    height: 1em;
+    width: 1em;
+    text-align: center;
+    margin-right: 0;
+  }
+
+  & .x-sb_lowerDrawer {
+    padding: 30px 0;
+    border-top: 1px solid #ddd;
+    width: 100%;
+  }
+
+  @media (max-width: 426px) {
+    width: 70%;
+  }
+
+  @media (min-width: 769px) {
+    width: 70px;
+
+    & .x-sb_workspaceInfo,
+    & .x-sb_optionName {
+      display: none;
+    }
+
+    & .x-sb_workspaceBox {
+      padding: 0;
+      margin: 0 auto;
+    }
+
+    & .x-sb_workspaceAdd {
+      margin-bottom: 20px;
+      gap: 0;
+      justify-content: center;
+    }
   }
 `;


### PR DESCRIPTION
<!-- Do not delete this PR template. Just edit it to include the required information -->

## Issue

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->
<!-- ( This could be an existing issue or a linear ticket ) -->
<!-- Github Issue Example: Closes #31 -->
<!-- Linear Ticket Example: Fixes ID-221 -->

<!-- **My PR Closes #issue_number_here** or -->
<!-- **My PR Fixes ID-linear_ticket_number_here** -->
My PR fixes the following issues:
- sidebar resizing
- flex inconsistencies of Workspace's main wrapper (container)
- workspace switching (WIP)

## What did you do?
<!-- Talk about the things you did eg. files changes, dependencies installed e.t.c -->
- I modularized the extra sidebar (which lists workspaces) on `Workspace.jsx` to enhance simplicity and ease of understanding (debugging)
```JavaScript
<>
  <ExtraSidebarWrapperStyle>
    <ExtraSidebar />
  </ExtraSidebarWrapperStyle>
  <SidebarWrapperStyle>
    <Sidebar />
  </SidebarWrapperStyle>
</>
```
- I modularized the functions required to fetch and format workspaces (and their data) and kept them in the same file - may be exported as utility functions later
- I fixed the whole container flex inconsistencies; resizable sidebar fitting to the center and the message board not filling full width.
- The sidebar resizes well and the message board now spans the whole available width as you resize the sidebar.

## Existing issues
- The problem of the plugin not reloading workspace data when workspaces are switched still persists (except on page reload). This PR follows a path to solve this problem by simplifying styles and functions.

## Proposition
- In this PR, workspace switching from the extra sidebar is triggered by a `Link` component. Therefore, on every workspace switch, the location `pathname` gets updated. Using this idea, changes can be made to the component which renders `zuri-plugin-load-section` to watch to updates to `pathname` and reload the necessary plugin. It is believed this implementation can be done on `zc_messaging`.
- Following this PR, I'm going to experiment with `zc_messaging` to see how the issue may be resolved.

# Check List (Check all the applicable boxes)

🚨Please review the [style guide for contributing](https://github.com/zurichat/zc_main/blob/dev/docs/STYLING.md) and [guidelines for contributing](https://github.com/zurichat/zc_main/blob/dev/docs/CONTRIBUTING.md) to this repository.

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the **dev branch** (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

# Screenshots/ Videos

https://user-images.githubusercontent.com/58527932/205997975-a165caf8-e904-4a70-861d-c2ac637c05d3.mp4



<!-- If the changes are static page changes or UI changes add screenshots -->
<!-- If the changes involve implementing a functionality or working with apis, include a video 
detailing how to implement the functionality and the request to the api and responses from the api endpoint-->
<!-- Add all the screenshots/videos which support your changes i.e before your change and after your change -->